### PR TITLE
refactor/dto

### DIFF
--- a/jarust/src/demux.rs
+++ b/jarust/src/demux.rs
@@ -37,7 +37,7 @@ impl Demux {
         {
             self.write().unwrap().channels.insert(namespace.into(), tx);
         }
-        log::trace!("Namespace created: {{ id: {namespace} }}");
+        log::trace!("Namespace created {{ id: {namespace} }}");
         rx
     }
 

--- a/jarust/src/dto/mod.rs
+++ b/jarust/src/dto/mod.rs
@@ -1,0 +1,1 @@
+pub mod response;

--- a/jarust/src/dto/response/mod.rs
+++ b/jarust/src/dto/response/mod.rs
@@ -1,0 +1,21 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct AttachResponse {
+    pub data: AttachInnerResponse,
+}
+
+#[derive(Deserialize)]
+pub struct AttachInnerResponse {
+    pub id: u64,
+}
+
+#[derive(Deserialize)]
+pub struct CreateSessionResponse {
+    pub data: CreateSessionInnerResponse,
+}
+
+#[derive(Deserialize)]
+pub struct CreateSessionInnerResponse {
+    pub id: u64,
+}

--- a/jarust/src/jaconnection.rs
+++ b/jarust/src/jaconnection.rs
@@ -1,4 +1,5 @@
 use crate::demux::Demux;
+use crate::dto::response::CreateSessionResponse;
 use crate::jaconfig::JaConfig;
 use crate::japrotocol::JaConnectionRequestProtocol;
 use crate::jasession::JaSession;
@@ -9,7 +10,6 @@ use crate::transport::trans::TransportProtocol;
 use crate::utils::generate_transaction;
 use crate::utils::get_subnamespace_from_request;
 use crate::utils::get_subnamespace_from_response;
-use serde::Deserialize;
 use serde_json::json;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -208,14 +208,4 @@ impl JaConnection {
             self.shared.config.root_namespace, namespace
         ))
     }
-}
-
-#[derive(Deserialize)]
-struct CreateSessionResponse {
-    data: CreateSessionInnerResponse,
-}
-
-#[derive(Deserialize)]
-struct CreateSessionInnerResponse {
-    id: u64,
 }

--- a/jarust/src/jaconnection.rs
+++ b/jarust/src/jaconnection.rs
@@ -105,16 +105,18 @@ impl JaConnection {
         let (transport_protocol, receiver) =
             TransportProtocol::connect(transport, &config.uri).await?;
 
-        let demux_clone = demux.clone();
-        let transaction_manager_clone = transaction_manager.clone();
-        tokio::runtime::Handle::current().spawn(async move {
-            JaConnection::demux_task(
-                receiver,
-                demux_clone,
-                transaction_manager_clone,
-                &root_namespace.clone(),
-            )
-            .await
+        tokio::spawn({
+            let demux = demux.clone();
+            let transaction_manager = transaction_manager.clone();
+            async move {
+                JaConnection::demux_task(
+                    receiver,
+                    demux,
+                    transaction_manager,
+                    &root_namespace.clone(),
+                )
+                .await
+            }
         });
 
         let shared = Shared { config };

--- a/jarust/src/jahandle.rs
+++ b/jarust/src/jahandle.rs
@@ -45,7 +45,7 @@ impl JaHandle {
         let (ack_sender, ack_receiver) = mpsc::channel(100);
         let (event_sender, event_receiver) = mpsc::channel(100);
 
-        tokio::runtime::Handle::current().spawn(async move {
+        tokio::spawn(async move {
             while let Some(item) = receiver.recv().await {
                 let response_type = serde_json::from_str::<JaResponse>(&item).unwrap();
                 match response_type.janus {

--- a/jarust/src/jasession.rs
+++ b/jarust/src/jasession.rs
@@ -67,8 +67,7 @@ impl JaSession {
 
         let this = session.clone();
 
-        let handle = tokio::runtime::Handle::current();
-        let _join_handle = handle.spawn(async move {
+        let _join_handle = tokio::spawn(async move {
             let _ = this.keep_alive(ka_interval).await;
         });
 

--- a/jarust/src/jasession.rs
+++ b/jarust/src/jasession.rs
@@ -1,8 +1,8 @@
+use crate::dto::response::AttachResponse;
 use crate::jaconnection::WeakJaConnection;
 use crate::jahandle::JaHandle;
 use crate::japrotocol::JaSessionRequestProtocol;
 use crate::prelude::*;
-use serde::Deserialize;
 use serde_json::json;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -108,7 +108,7 @@ impl JaSession {
             .handles
             .insert(handle_id, handle.clone());
 
-        log::info!("Handle created {{ id: {} }}", handle_id);
+        log::info!("Handle created {{ id: {handle_id} }}");
 
         Ok((handle, event_receiver))
     }
@@ -126,31 +126,17 @@ impl JaSession {
         let id = { self.shared.id };
         loop {
             interval.tick().await;
-            log::trace!(
-                "Sending keep-alive {{ id: {}, timeout: {}s }}",
-                id,
-                ka_interval
-            );
+            log::trace!("Sending keep-alive {{ id: {id}, timeout: {ka_interval}s }}");
             self.send_request(json!({
                 "janus": JaSessionRequestProtocol::KeepAlive,
             }))
             .await?;
             self.safe.lock().await.receiver.recv().await.unwrap();
-            log::trace!("keep-alive OK {{ id: {} }}", id);
+            log::trace!("keep-alive OK {{ id: {id} }}");
         }
     }
 
     pub(crate) fn downgrade(&self) -> WeakJaSession {
         WeakJaSession(Arc::downgrade(self))
     }
-}
-
-#[derive(Deserialize)]
-struct AttachResponse {
-    data: AttachInnerResponse,
-}
-
-#[derive(Deserialize)]
-struct AttachInnerResponse {
-    id: u64,
 }

--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -9,6 +9,7 @@ pub mod prelude;
 pub mod transport;
 
 mod demux;
+mod dto;
 mod error;
 mod jaconnection;
 mod jahandle;


### PR DESCRIPTION
- refactor: moved responses to the dto dir
- feat: shadowing instead of _clone, and used tokio::spawn
