### PR TITLE
feat: laying the first stone for wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,5 @@ repository = "https://github.com/Ghamza-Jd/jarust"
 [workspace.dependencies]
 async-trait = "0.1.77"
 log = "0.4.20"
-tokio = { version = "1.35.1", features = ["sync", "time", "rt"] }
-tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -21,8 +21,8 @@ rand = "0.8.5"
 serde_json.workspace = true
 serde.workspace = true
 thiserror = "1.0.51"
-tokio-tungstenite.workspace = true
-tokio.workspace = true
+tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
+tokio = { version = "1.35.1", features = ["sync", "time", "rt"] }
 
 [dev-dependencies]
 anyhow = "1.0.79"

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -21,8 +21,14 @@ rand = "0.8.5"
 serde_json.workspace = true
 serde.workspace = true
 thiserror = "1.0.51"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 tokio = { version = "1.35.1", features = ["sync", "time", "rt"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+getrandom = { version = "0.2.12", features = ["js"] }
+web-sys = { version = "0.3.67", features = ["WebSocket", "MessageEvent"] }
 
 [dev-dependencies]
 anyhow = "1.0.79"

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -21,14 +21,13 @@ rand = "0.8.5"
 serde_json.workspace = true
 serde.workspace = true
 thiserror = "1.0.51"
+tokio = { version = "1.35.1", features = ["sync", "time", "rt"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
-tokio = { version = "1.35.1", features = ["sync", "time", "rt"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
-web-sys = { version = "0.3.67", features = ["WebSocket", "MessageEvent"] }
 
 [dev-dependencies]
 anyhow = "1.0.79"

--- a/jarust/src/error.rs
+++ b/jarust/src/error.rs
@@ -1,17 +1,19 @@
-use tokio_tungstenite::tungstenite;
-use tokio_tungstenite::tungstenite::http::header::InvalidHeaderValue;
-
 #[derive(thiserror::Error, Debug)]
 pub enum JaError {
     /* Transformed Errors */
+    #[cfg(not(target_family = "wasm"))]
     #[error("Websocket error: {0}")]
-    WebSocket(#[from] tungstenite::Error),
+    WebSocket(#[from] tokio_tungstenite::tungstenite::Error),
+
+    #[cfg(not(target_family = "wasm"))]
     #[error("InvalidHeaderValue: {0}")]
-    InvalidHeaderValue(#[from] InvalidHeaderValue),
+    InvalidHeaderValue(#[from] tokio_tungstenite::tungstenite::http::header::InvalidHeaderValue),
+
     #[error("Failed to parse json: {0}")]
     JsonParsingFailure(#[from] serde_json::Error),
     #[error("IO: {0}")]
     IO(#[from] std::io::Error),
+
     /* Custom Errors */
     #[error("Error while parsing an incomplete packet")]
     IncompletePacket,

--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -1,9 +1,3 @@
-use crate::transport::trans::Transport;
-use jaconfig::JaConfig;
-use jaconfig::TransportType;
-use jaconnection::JaConnection;
-use prelude::JaResult;
-
 pub mod error;
 pub mod jaconfig;
 pub mod jaconnection;
@@ -18,12 +12,25 @@ mod nsp_registry;
 mod tmanager;
 mod utils;
 
+use crate::transport::trans::Transport;
+use jaconfig::JaConfig;
+use jaconfig::TransportType;
+use jaconnection::JaConnection;
+use prelude::JaResult;
+
 #[cfg(not(target_family = "wasm"))]
 /// Creates a new connection with janus server from the provided configs
 pub async fn connect(jaconfig: JaConfig, transport_type: TransportType) -> JaResult<JaConnection> {
     let transport = match transport_type {
         jaconfig::TransportType::Wss => transport::wss::WebsocketTransport::new(),
     };
+    connect_with_transport(jaconfig, transport).await
+}
+
+#[cfg(target_family = "wasm")]
+/// Creates a new connection with janus server from the provided configs
+pub async fn connect(jaconfig: JaConfig, transport_type: TransportType) -> JaResult<JaConnection> {
+    let transport = transport::wasm_wss::WasmWsTransport;
     connect_with_transport(jaconfig, transport).await
 }
 

--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -18,6 +18,7 @@ mod nsp_registry;
 mod tmanager;
 mod utils;
 
+#[cfg(not(target_family = "wasm"))]
 /// Creates a new connection with janus server from the provided configs
 pub async fn connect(jaconfig: JaConfig, transport_type: TransportType) -> JaResult<JaConnection> {
     let transport = match transport_type {

--- a/jarust/src/transport/mod.rs
+++ b/jarust/src/transport/mod.rs
@@ -1,2 +1,5 @@
 pub mod trans;
+#[cfg(target_family = "wasm")]
+pub mod wasm_wss;
+#[cfg(not(target_family = "wasm"))]
 pub mod wss;

--- a/jarust/src/transport/wasm_wss.rs
+++ b/jarust/src/transport/wasm_wss.rs
@@ -13,7 +13,6 @@ impl Transport for WasmWsTransport {
 
     async fn connect(&mut self, uri: &str) -> JaResult<mpsc::Receiver<String>> {
         log::error!("WASM support is WIP!");
-        let websocket = web_sys::WebSocket::new_with_str(uri, "janus-protocol").unwrap();
         todo!("WASM support is WIP!")
     }
 

--- a/jarust/src/transport/wasm_wss.rs
+++ b/jarust/src/transport/wasm_wss.rs
@@ -1,0 +1,24 @@
+use super::trans::Transport;
+use crate::prelude::*;
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+pub struct WasmWsTransport;
+
+#[async_trait]
+impl Transport for WasmWsTransport {
+    fn new() -> Self {
+        Self
+    }
+
+    async fn connect(&mut self, uri: &str) -> JaResult<mpsc::Receiver<String>> {
+        log::error!("WASM support is WIP!");
+        let websocket = web_sys::WebSocket::new_with_str(uri, "janus-protocol").unwrap();
+        todo!("WASM support is WIP!")
+    }
+
+    async fn send(&mut self, _data: &[u8]) -> JaResult<()> {
+        log::error!("WASM support is WIP!");
+        todo!("WASM support is WIP!")
+    }
+}


### PR DESCRIPTION
- Moved non-wasm compatible dependencies under target family `!=` wasm
- Created wasm transport placeholder and passed it to the connection function when the target is wasm

The next wasm PR should be about adding the actual transport logic