### PR TITLE
chore: expose jaconnection and error to the lib user

### DIFF
--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -4,7 +4,9 @@ use jaconfig::TransportType;
 use jaconnection::JaConnection;
 use prelude::JaResult;
 
+pub mod error;
 pub mod jaconfig;
+pub mod jaconnection;
 pub mod jahandle;
 pub mod japlugin;
 pub mod japrotocol;
@@ -12,8 +14,6 @@ pub mod jasession;
 pub mod prelude;
 pub mod transport;
 
-mod error;
-mod jaconnection;
 mod nsp_registry;
 mod tmanager;
 mod utils;


### PR DESCRIPTION
`JaConnection` isn't exposed, so we can't store it in a struct since the lib user
don't have access to the type.

Currently, it's only accessible via the `connect` function which returns an instance of `JaConnection`.