### PR TITLE
feat/tokio tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ async-trait = "0.1.77"
 log = "0.4.20"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
+tracing = "0.1.40"

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -33,7 +33,6 @@ getrandom = { version = "0.2.12", features = ["js"] }
 
 [dev-dependencies]
 anyhow = "1.0.79"
-simple_logger = "4.3.3"
 tokio = { version = "1.35.1", features = ["time", "macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -16,12 +16,12 @@ doctest = false
 [dependencies]
 async-trait.workspace = true
 futures-util = "0.3.29"
-log.workspace = true
 rand = "0.8.5"
 serde_json.workspace = true
 serde.workspace = true
 thiserror = "1.0.51"
 tokio = { version = "1.35.1", features = ["sync", "time", "rt"] }
+tracing.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rustls = "0.22.2"
@@ -35,6 +35,7 @@ getrandom = { version = "0.2.12", features = ["js"] }
 anyhow = "1.0.79"
 simple_logger = "4.3.3"
 tokio = { version = "1.35.1", features = ["time", "macros", "rt-multi-thread"] }
+tracing-subscriber = "0.3.18"
 
 [features]
 default = ["tokio-rt"]

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -35,7 +35,7 @@ getrandom = { version = "0.2.12", features = ["js"] }
 anyhow = "1.0.79"
 simple_logger = "4.3.3"
 tokio = { version = "1.35.1", features = ["time", "macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [features]
 default = ["tokio-rt"]

--- a/jarust/README.md
+++ b/jarust/README.md
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     while let Some(event) = event_receiver.recv().await {
-        log::info!("response: {event:?}");
+        tracing::info!("response: {event:?}");
     }
 
     Ok(())

--- a/jarust/README.md
+++ b/jarust/README.md
@@ -23,14 +23,14 @@ Checkout the existing plugins: [jarust_plugins](https://crates.io/crates/jarust_
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust::japlugin::Attach;
-use log::LevelFilter;
-use log::SetLoggerError;
 use serde_json::json;
-use simple_logger::SimpleLogger;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -48,20 +48,9 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     while let Some(event) = event_receiver.recv().await {
-        tracing::info!("response: {event:?}");
+        tracing::info!("response: {event:#?}");
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .with_module_level("rustls", LevelFilter::Off)
-        .init()
 }
 ```

--- a/jarust/examples/raw_echotest.rs
+++ b/jarust/examples/raw_echotest.rs
@@ -2,10 +2,13 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust::japlugin::Attach;
 use serde_json::json;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust/examples/raw_echotest.rs
+++ b/jarust/examples/raw_echotest.rs
@@ -1,14 +1,11 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust::japlugin::Attach;
-use log::LevelFilter;
-use log::SetLoggerError;
 use serde_json::json;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -26,19 +23,8 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     while let Some(event) = event_receiver.recv().await {
-        log::info!("response: {event:?}");
+        tracing::info!("response: {event:?}");
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .with_module_level("rustls", LevelFilter::Off)
-        .init()
 }

--- a/jarust/examples/raw_echotest.rs
+++ b/jarust/examples/raw_echotest.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     while let Some(event) = event_receiver.recv().await {
-        tracing::info!("response: {event:?}");
+        tracing::info!("response: {event:#?}");
     }
 
     Ok(())

--- a/jarust/examples/secure_ws.rs
+++ b/jarust/examples/secure_ws.rs
@@ -1,14 +1,11 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust::japlugin::Attach;
-use log::LevelFilter;
-use log::SetLoggerError;
 use serde_json::json;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("wss://janus.conf.meetecho.com/ws", None, "janus"),
@@ -26,19 +23,8 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     while let Some(event) = event_receiver.recv().await {
-        log::info!("response: {event:?}");
+        tracing::info!("response: {event:?}");
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .with_module_level("rustls", LevelFilter::Off)
-        .init()
 }

--- a/jarust/examples/secure_ws.rs
+++ b/jarust/examples/secure_ws.rs
@@ -5,7 +5,9 @@ use serde_json::json;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("wss://janus.conf.meetecho.com/ws", None, "janus"),
@@ -23,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     while let Some(event) = event_receiver.recv().await {
-        tracing::info!("response: {event:?}");
+        tracing::info!("response: {event:#?}");
     }
 
     Ok(())

--- a/jarust/examples/secure_ws.rs
+++ b/jarust/examples/secure_ws.rs
@@ -2,11 +2,12 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust::japlugin::Attach;
 use serde_json::json;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
         .init();
 
     let mut connection = jarust::connect(

--- a/jarust/src/jaconnection.rs
+++ b/jarust/src/jaconnection.rs
@@ -116,7 +116,7 @@ impl JaConnection {
 
     /// Creates a new session with janus server.
     pub async fn create(&mut self, ka_interval: u32) -> JaResult<JaSession> {
-        log::info!("Creating new session");
+        tracing::info!("Creating new session");
 
         let request = json!({
             "janus": JaConnectionRequestProtocol::CreateSession,
@@ -126,7 +126,7 @@ impl JaConnection {
         let response = match self.inner.exclusive.lock().await.receiver.recv().await {
             Some(response) => response,
             None => {
-                log::error!("Incomplete packet");
+                tracing::error!("Incomplete packet");
                 return Err(JaError::IncompletePacket);
             }
         };
@@ -138,11 +138,11 @@ impl JaConnection {
                     code: error.code,
                     reason: error.reason,
                 };
-                log::error!("{what}");
+                tracing::error!("{what}");
                 return Err(what);
             }
             _ => {
-                log::error!("Unexpected response");
+                tracing::error!("Unexpected response");
                 return Err(JaError::UnexpectedResponse);
             }
         };
@@ -157,7 +157,7 @@ impl JaConnection {
             .sessions
             .insert(session_id, session.downgrade());
 
-        log::info!("Session created {{ id: {session_id} }}");
+        tracing::info!("Session created {{ id: {session_id} }}");
 
         Ok(session)
     }
@@ -171,7 +171,7 @@ impl JaConnection {
         let response = match self.inner.exclusive.lock().await.receiver.recv().await {
             Some(response) => response,
             None => {
-                log::error!("Incomplete packet");
+                tracing::error!("Incomplete packet");
                 return Err(JaError::IncompletePacket);
             }
         };
@@ -188,7 +188,7 @@ impl JaConnection {
             let err = JaError::InvalidJanusRequest {
                 reason: "request type and/or transaction are missing".to_owned(),
             };
-            log::error!("{err}");
+            tracing::error!("{err}");
             return Err(err);
         };
 
@@ -222,7 +222,7 @@ impl JaConnection {
 
 impl Drop for InnerConnection {
     fn drop(&mut self) {
-        log::trace!("Connection dropped");
+        tracing::trace!("Connection dropped");
         self.shared.demux_abort_handle.abort();
     }
 }

--- a/jarust/src/jahandle.rs
+++ b/jarust/src/jahandle.rs
@@ -131,13 +131,13 @@ impl JaHandle {
                 match serde_json::from_value::<R>(plugin_data) {
                     Ok(result) => result,
                     Err(error) => {
-                        log::error!("Failed to parse with error {error:#?}");
+                        tracing::error!("Failed to parse with error {error:#?}");
                         return Err(JaError::UnexpectedResponse);
                     }
                 }
             }
             _ => {
-                log::error!("Request failed");
+                tracing::error!("Request failed");
                 return Err(JaError::UnexpectedResponse);
             }
         };
@@ -155,7 +155,7 @@ impl JaHandle {
         let response = match self.inner.exclusive.lock().await.ack_receiver.recv().await {
             Some(response) => response,
             None => {
-                log::error!("Incomplete packet");
+                tracing::error!("Incomplete packet");
                 return Err(JaError::IncompletePacket);
             }
         };
@@ -191,7 +191,7 @@ impl JaHandle {
     }
 
     pub async fn detach(&self) -> JaResult<()> {
-        log::info!("Detaching handle {{ id: {} }}", self.inner.shared.id);
+        tracing::info!("Detaching handle {{ id: {} }}", self.inner.shared.id);
         let request = json!({
             "janus": JaHandleRequestProtocol::DetachPlugin,
         });
@@ -209,7 +209,7 @@ impl JaHandle {
 
 impl Drop for InnerHandle {
     fn drop(&mut self) {
-        log::trace!("Dropping handle {{ id: {} }}", self.shared.id);
+        tracing::trace!("Dropping handle {{ id: {} }}", self.shared.id);
         self.shared.abort_handle.abort();
     }
 }

--- a/jarust/src/jarouter.rs
+++ b/jarust/src/jarouter.rs
@@ -55,7 +55,7 @@ impl JaRouter {
                 .routes
                 .insert(path.into(), tx);
         }
-        log::trace!("Route created {{ path: {path} }}");
+        tracing::trace!("Route created {{ path: {path} }}");
         rx
     }
 

--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -17,6 +17,7 @@ use jaconfig::JaConfig;
 use jaconfig::TransportType;
 use jaconnection::JaConnection;
 use prelude::JaResult;
+use tracing::Level;
 
 #[cfg(not(target_family = "wasm"))]
 /// Creates a new connection with janus server from the provided configs
@@ -35,11 +36,11 @@ pub async fn connect(jaconfig: JaConfig, transport_type: TransportType) -> JaRes
 }
 
 /// Creates a new connection with janus server from the provided configs and custom transport
+#[tracing::instrument(level = Level::TRACE)]
 pub async fn connect_with_transport(
     jaconfig: JaConfig,
     transport: impl Transport,
 ) -> JaResult<JaConnection> {
     tracing::info!("Creating new connection");
-    tracing::trace!("Creating connection with server configuration {jaconfig:?}");
     JaConnection::open(jaconfig, transport).await
 }

--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -39,7 +39,7 @@ pub async fn connect_with_transport(
     jaconfig: JaConfig,
     transport: impl Transport,
 ) -> JaResult<JaConnection> {
-    log::info!("Creating new connection");
-    log::trace!("Creating connection with server configuration {jaconfig:?}");
+    tracing::info!("Creating new connection");
+    tracing::trace!("Creating connection with server configuration {jaconfig:?}");
     JaConnection::open(jaconfig, transport).await
 }

--- a/jarust/src/tmanager.rs
+++ b/jarust/src/tmanager.rs
@@ -93,6 +93,7 @@ impl TransactionManager {
         tracing::trace!("Transaction created {{ id: {id}, path: {path}, request: {request} }}");
     }
 
+    #[tracing::instrument(parent = None, skip(self))]
     pub(crate) fn success_close(&self, id: &str) {
         let tx = self.get(id);
         if let Some(tx) = tx {

--- a/jarust/src/tmanager.rs
+++ b/jarust/src/tmanager.rs
@@ -37,7 +37,7 @@ impl DerefMut for TransactionManager {
 
 impl TransactionManager {
     pub(crate) fn new() -> Self {
-        log::trace!("Creating new transaction manager");
+        tracing::trace!("Creating new transaction manager");
         let transactions = HashMap::new();
         Self(Arc::new(RwLock::new(Inner { transactions })))
     }
@@ -90,14 +90,14 @@ impl TransactionManager {
         };
 
         self.insert(id, pending_transaction);
-        log::trace!("Transaction created {{ id: {id}, path: {path}, request: {request} }}");
+        tracing::trace!("Transaction created {{ id: {id}, path: {path}, request: {request} }}");
     }
 
     pub(crate) fn success_close(&self, id: &str) {
         let tx = self.get(id);
         if let Some(tx) = tx {
             self.remove(&tx.id);
-            log::trace!(
+            tracing::trace!(
                 "Transaction closed successfully {{ id: {}, path: {}, request: {} }}",
                 tx.id,
                 tx.path,

--- a/jarust/src/transport/trans.rs
+++ b/jarust/src/transport/trans.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use tokio::sync::mpsc;
 
 #[async_trait]
-pub trait Transport: Send + Sync + 'static {
+pub trait Transport: Debug + Send + Sync + 'static {
     fn new() -> Self
     where
         Self: Sized;

--- a/jarust/src/transport/wasm_web_socket.rs
+++ b/jarust/src/transport/wasm_web_socket.rs
@@ -12,12 +12,12 @@ impl Transport for WasmWsTransport {
     }
 
     async fn connect(&mut self, uri: &str) -> JaResult<mpsc::Receiver<String>> {
-        log::error!("WASM support is WIP!");
+        tracing::error!("WASM support is WIP!");
         todo!("WASM support is WIP!")
     }
 
     async fn send(&mut self, _data: &[u8]) -> JaResult<()> {
-        log::error!("WASM support is WIP!");
+        tracing::error!("WASM support is WIP!");
         todo!("WASM support is WIP!")
     }
 }

--- a/jarust/src/transport/wasm_wss.rs
+++ b/jarust/src/transport/wasm_wss.rs
@@ -12,12 +12,12 @@ impl Transport for WasmWsTransport {
     }
 
     async fn connect(&mut self, uri: &str) -> JaResult<mpsc::Receiver<String>> {
-        log::error!("WASM support is WIP!");
+        tracing::error!("WASM support is WIP!");
         todo!("WASM support is WIP!")
     }
 
     async fn send(&mut self, _data: &[u8]) -> JaResult<()> {
-        log::error!("WASM support is WIP!");
+        tracing::error!("WASM support is WIP!");
         todo!("WASM support is WIP!")
     }
 }

--- a/jarust/src/transport/web_socket.rs
+++ b/jarust/src/transport/web_socket.rs
@@ -64,7 +64,7 @@ impl Transport for WebsocketTransport {
         if let Some(sender) = &mut self.sender {
             sender.send(item).await?;
         } else {
-            log::error!("Transport not opened!");
+            tracing::error!("Transport not opened!");
             return Err(JaError::TransportNotOpened);
         }
         Ok(())
@@ -86,7 +86,7 @@ impl WebsocketTransport {
 impl Drop for WebsocketTransport {
     fn drop(&mut self) {
         if let Some(join_handle) = self.abort_handle.take() {
-            log::trace!("Dropping wss transport");
+            tracing::trace!("Dropping wss transport");
             join_handle.abort();
         }
     }

--- a/jarust/src/transport/web_socket.rs
+++ b/jarust/src/transport/web_socket.rs
@@ -8,6 +8,7 @@ use futures_util::stream::SplitSink;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
 use rustls::RootCertStore;
+use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
@@ -89,5 +90,11 @@ impl Drop for WebsocketTransport {
             tracing::trace!("Dropping wss transport");
             join_handle.abort();
         }
+    }
+}
+
+impl Debug for WebsocketTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Websocket").finish()
     }
 }

--- a/jarust/tests/mocks/mock_transport.rs
+++ b/jarust/tests/mocks/mock_transport.rs
@@ -3,6 +3,7 @@ use jarust::jatask;
 use jarust::jatask::AbortHandle;
 use jarust::prelude::*;
 use jarust::transport::trans::Transport;
+use std::fmt::Debug;
 use tokio::sync::mpsc;
 
 pub struct MockServer {
@@ -66,5 +67,11 @@ impl Drop for MockTransport {
         if let Some(abort_handle) = self.abort_handle.take() {
             abort_handle.abort();
         }
+    }
+}
+
+impl Debug for MockTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Mock").finish()
     }
 }

--- a/jarust_make_plugin/README.md
+++ b/jarust_make_plugin/README.md
@@ -129,7 +129,7 @@ impl EchoTest for JaSession {
                 serde_json::from_value::<EchoTestPluginData>(plugin_data)?.event
             }
             _ => {
-                log::error!("unexpected response");
+                tracing::error!("unexpected response");
                 return Err(JaError::UnexpectedResponse);
             }
         };

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -29,6 +29,5 @@ audio_bridge = []
 
 [dev-dependencies]
 anyhow = "1.0.79"
-simple_logger = "4.3.3"
 tokio = { version = "1.35.1", features = ["time", "macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -17,10 +17,10 @@ doctest = false
 async-trait.workspace = true
 jarust = { version = "0.2.0", path = "../jarust" }
 jarust_make_plugin = { version = "0.2.0", path = "../jarust_make_plugin" }
-log.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 tokio = { version = "1.35.1", features = ["sync"] }
+tracing.workspace = true
 
 [features]
 default = ["echotest", "audio_bridge"]
@@ -31,3 +31,4 @@ audio_bridge = []
 anyhow = "1.0.79"
 simple_logger = "4.3.3"
 tokio = { version = "1.35.1", features = ["time", "macros", "rt-multi-thread"] }
+tracing-subscriber = "0.3.18"

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -31,4 +31,4 @@ audio_bridge = []
 anyhow = "1.0.79"
 simple_logger = "4.3.3"
 tokio = { version = "1.35.1", features = ["time", "macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/jarust_plugins/README.md
+++ b/jarust_plugins/README.md
@@ -16,13 +16,13 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::echotest::events::EchoTestPluginEvent;
 use jarust_plugins::echotest::messages::EchoTestStartMsg;
 use jarust_plugins::echotest::EchoTest;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -50,17 +50,6 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .with_module_level("rustls", LevelFilter::Off)
-        .init()
-}
 ```
 
 ## AudioBridge Example
@@ -69,13 +58,13 @@ fn init_logger() -> Result<(), SetLoggerError> {
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -89,15 +78,5 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Rooms {:#?}", result);
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }
 ```

--- a/jarust_plugins/README.md
+++ b/jarust_plugins/README.md
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
     while let Some(event) = event_receiver.recv().await {
         match event {
             EchoTestPluginEvent::Result { result, .. } => {
-                log::info!("result: {result}");
+                tracing::info!("result: {result}");
             }
         }
     }
@@ -86,7 +86,7 @@ async fn main() -> anyhow::Result<()> {
     let (handle, ..) = session.attach_audio_bridge().await?;
 
     let result = handle.list().await?;
-    log::info!("Rooms {:#?}", result);
+    tracing::info!("Rooms {:#?}", result);
 
     Ok(())
 }

--- a/jarust_plugins/examples/audio_bridge_allowed.rs
+++ b/jarust_plugins/examples/audio_bridge_allowed.rs
@@ -4,10 +4,13 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeAction;
 use jarust_plugins::audio_bridge::messages::AudioBridgeAllowedOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_allowed.rs
+++ b/jarust_plugins/examples/audio_bridge_allowed.rs
@@ -4,13 +4,10 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeAction;
 use jarust_plugins::audio_bridge::messages::AudioBridgeAllowedOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -26,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?;
-    log::info!("Created Room {}, permanent: {}", room, permanent);
+    tracing::info!("Created Room {}, permanent: {}", room, permanent);
 
     let (room, allowed_participants) = handle
         .allowed(
@@ -39,21 +36,11 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
-    log::info!(
+    tracing::info!(
         "Allowed participants in room {}: {:#?}",
         room,
         allowed_participants
     );
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_create_room.rs
+++ b/jarust_plugins/examples/audio_bridge_create_room.rs
@@ -2,13 +2,10 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -24,17 +21,7 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?;
-    log::info!("Created Room {}, permanent: {}", room, permanent);
+    tracing::info!("Created Room {}, permanent: {}", room, permanent);
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_create_room.rs
+++ b/jarust_plugins/examples/audio_bridge_create_room.rs
@@ -2,10 +2,13 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_destroy.rs
+++ b/jarust_plugins/examples/audio_bridge_destroy.rs
@@ -3,13 +3,10 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeDestroyOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -38,17 +35,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
-    log::info!("Detroyed Room {}, permanent: {}", room, permanent);
+    tracing::info!("Detroyed Room {}, permanent: {}", room, permanent);
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_destroy.rs
+++ b/jarust_plugins/examples/audio_bridge_destroy.rs
@@ -3,10 +3,13 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeDestroyOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_destroy_all_rooms.rs
+++ b/jarust_plugins/examples/audio_bridge_destroy_all_rooms.rs
@@ -2,13 +2,10 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeDestroyOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -20,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
 
     let list = handle.list().await?;
 
-    log::info!("Rooms to destroy {:#?}", list);
+    tracing::info!("Rooms to destroy {:#?}", list);
 
     for item in list {
         if let Ok((room, ..)) = handle
@@ -33,19 +30,9 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
         {
-            log::info!("Destroyed Room {}", room);
+            tracing::info!("Destroyed Room {}", room);
         };
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_destroy_all_rooms.rs
+++ b/jarust_plugins/examples/audio_bridge_destroy_all_rooms.rs
@@ -2,10 +2,13 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeDestroyOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_edit.rs
+++ b/jarust_plugins/examples/audio_bridge_edit.rs
@@ -3,10 +3,13 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeEditOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_edit.rs
+++ b/jarust_plugins/examples/audio_bridge_edit.rs
@@ -3,13 +3,10 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeEditOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -39,17 +36,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
-    log::info!("Edited Room {}", room);
+    tracing::info!("Edited Room {}", room);
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_exists.rs
+++ b/jarust_plugins/examples/audio_bridge_exists.rs
@@ -3,10 +3,13 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeDestroyOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_exists.rs
+++ b/jarust_plugins/examples/audio_bridge_exists.rs
@@ -3,13 +3,10 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeDestroyOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -20,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
     let (handle, ..) = session.attach_audio_bridge().await?;
 
     let exist = handle.exists(4321).await?;
-    log::info!("Room exists?: {}", exist);
+    tracing::info!("Room exists?: {}", exist);
 
     if !exist {
         let _ = handle
@@ -32,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
             .await?;
 
         let exist = handle.exists(4321).await?;
-        log::info!("Room exists?: {}", exist);
+        tracing::info!("Room exists?: {}", exist);
 
         if exist {
             let _ = handle
@@ -46,19 +43,9 @@ async fn main() -> anyhow::Result<()> {
                 .await;
 
             let exist = handle.exists(4321).await?;
-            log::info!("Room exists?: {}", exist);
+            tracing::info!("Room exists?: {}", exist);
         }
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_join_room.rs
+++ b/jarust_plugins/examples/audio_bridge_join_room.rs
@@ -3,10 +3,13 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_join_room.rs
+++ b/jarust_plugins/examples/audio_bridge_join_room.rs
@@ -3,13 +3,10 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -25,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?;
-    log::info!("Created Room {}, permanent: {}", room, permanent);
+    tracing::info!("Created Room {}, permanent: {}", room, permanent);
 
     let _ = handle
         .join_room(
@@ -40,18 +37,8 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     if let Some((event, protocol)) = event_receiver.recv().await {
-        log::info!("Joined Room {}, {:#?}, {:#?}", room, event, protocol);
+        tracing::info!("Joined Room {}, {:#?}, {:#?}", room, event, protocol);
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_kick.rs
+++ b/jarust_plugins/examples/audio_bridge_kick.rs
@@ -5,13 +5,10 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeKickOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -27,7 +24,7 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?;
-    log::info!("Created Room {}, permanent: {}", room, permanent);
+    tracing::info!("Created Room {}, permanent: {}", room, permanent);
 
     let _ = handle
         .join_room(
@@ -44,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some((event, ..)) = event_receiver.recv().await {
         match event {
             AudioBridgePluginEvent::JoinRoom { id, room, .. } => {
-                log::info!("Joined room {}, Paricipant id: {}", room, id);
+                tracing::info!("Joined room {}, Paricipant id: {}", room, id);
 
                 let kick_result = handle
                     .kick(
@@ -56,21 +53,11 @@ async fn main() -> anyhow::Result<()> {
                     )
                     .await;
                 if let Ok(()) = kick_result {
-                    log::info!("Paricipant {} Kicked", id);
+                    tracing::info!("Paricipant {} Kicked", id);
                 }
             }
         }
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_kick.rs
+++ b/jarust_plugins/examples/audio_bridge_kick.rs
@@ -5,10 +5,13 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeKickOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_kick_all.rs
+++ b/jarust_plugins/examples/audio_bridge_kick_all.rs
@@ -5,10 +5,13 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeKickAllOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_list.rs
+++ b/jarust_plugins/examples/audio_bridge_list.rs
@@ -1,13 +1,10 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -18,17 +15,7 @@ async fn main() -> anyhow::Result<()> {
     let (handle, ..) = session.attach_audio_bridge().await?;
 
     let result = handle.list().await?;
-    log::info!("Rooms {:#?}", result);
+    tracing::info!("Rooms {:#?}", result);
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_list.rs
+++ b/jarust_plugins/examples/audio_bridge_list.rs
@@ -1,10 +1,13 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_list_participants.rs
+++ b/jarust_plugins/examples/audio_bridge_list_participants.rs
@@ -2,10 +2,13 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_list_participants.rs
+++ b/jarust_plugins/examples/audio_bridge_list_participants.rs
@@ -2,13 +2,10 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -24,20 +21,10 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?;
-    log::info!("Created Room {}, permanent: {}", room, permanent);
+    tracing::info!("Created Room {}, permanent: {}", room, permanent);
 
     let (room, participants) = handle.list_participants(room).await?;
-    log::info!("Participants in room {}: {:#?}", room, participants);
+    tracing::info!("Participants in room {}: {:#?}", room, participants);
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_suspend.rs
+++ b/jarust_plugins/examples/audio_bridge_suspend.rs
@@ -5,13 +5,10 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeSuspendOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -27,7 +24,7 @@ async fn main() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?;
-    log::info!("Created Room {}, permanent: {}", room, permanent);
+    tracing::info!("Created Room {}, permanent: {}", room, permanent);
 
     let _ = handle
         .join_room(
@@ -44,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some((event, ..)) = event_receiver.recv().await {
         match event {
             AudioBridgePluginEvent::JoinRoom { id, room, .. } => {
-                log::info!("Joined room {}, Paricipant id: {}", room, id);
+                tracing::info!("Joined room {}, Paricipant id: {}", room, id);
 
                 let suspend_result = handle
                     .suspend(
@@ -57,21 +54,11 @@ async fn main() -> anyhow::Result<()> {
                     )
                     .await;
                 if let Ok(()) = suspend_result {
-                    log::info!("Paricipant {} suspended", id);
+                    tracing::info!("Paricipant {} suspended", id);
                 }
             }
         }
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/examples/audio_bridge_suspend.rs
+++ b/jarust_plugins/examples/audio_bridge_suspend.rs
@@ -5,10 +5,13 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeCreateOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeSuspendOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/audio_bridge_suspend_and_resume.rs
+++ b/jarust_plugins/examples/audio_bridge_suspend_and_resume.rs
@@ -6,10 +6,13 @@ use jarust_plugins::audio_bridge::messages::AudioBridgeJoinOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeResumeOptions;
 use jarust_plugins::audio_bridge::messages::AudioBridgeSuspendOptions;
 use jarust_plugins::audio_bridge::AudioBridge;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/echotest.rs
+++ b/jarust_plugins/examples/echotest.rs
@@ -3,10 +3,13 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::echotest::events::EchoTestPluginEvent;
 use jarust_plugins::echotest::messages::EchoTestStartMsg;
 use jarust_plugins::echotest::EchoTest;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("jarust=trace".parse()?))
+        .init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),

--- a/jarust_plugins/examples/echotest.rs
+++ b/jarust_plugins/examples/echotest.rs
@@ -3,13 +3,10 @@ use jarust::jaconfig::TransportType;
 use jarust_plugins::echotest::events::EchoTestPluginEvent;
 use jarust_plugins::echotest::messages::EchoTestStartMsg;
 use jarust_plugins::echotest::EchoTest;
-use log::LevelFilter;
-use log::SetLoggerError;
-use simple_logger::SimpleLogger;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    init_logger()?;
+    tracing_subscriber::fmt::init();
 
     let mut connection = jarust::connect(
         JaConfig::new("ws://localhost:8188/ws", None, "janus"),
@@ -30,21 +27,10 @@ async fn main() -> anyhow::Result<()> {
     while let Some(event) = event_receiver.recv().await {
         match event {
             EchoTestPluginEvent::Result { result, .. } => {
-                log::info!("result: {result}");
+                tracing::info!("result: {result}");
             }
         }
     }
 
     Ok(())
-}
-
-fn init_logger() -> Result<(), SetLoggerError> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Trace)
-        .with_colors(true)
-        .with_module_level("tokio_tungstenite", LevelFilter::Off)
-        .with_module_level("tungstenite", LevelFilter::Off)
-        .with_module_level("want", LevelFilter::Off)
-        .with_module_level("rustls", LevelFilter::Off)
-        .init()
 }

--- a/jarust_plugins/src/audio_bridge/mod.rs
+++ b/jarust_plugins/src/audio_bridge/mod.rs
@@ -25,7 +25,7 @@ impl AudioBridge for JaSession {
                 message.establishment_protocol,
             ),
             _ => {
-                log::error!("unexpected response");
+                tracing::error!("unexpected response");
                 return Err(JaError::UnexpectedResponse);
             }
         };

--- a/jarust_plugins/src/echotest/handle.rs
+++ b/jarust_plugins/src/echotest/handle.rs
@@ -18,7 +18,7 @@ impl EchoTestHandle {
             let err = JaError::InvalidJanusRequest {
                 reason: "jsep must be an offer".to_owned(),
             };
-            log::error!("{err}");
+            tracing::error!("{err}");
             return Err(err);
         }
         self.handle

--- a/jarust_plugins/src/echotest/mod.rs
+++ b/jarust_plugins/src/echotest/mod.rs
@@ -22,7 +22,7 @@ impl EchoTest for JaSession {
                 serde_json::from_value::<EchoTestPluginData>(plugin_data)?.event
             }
             _ => {
-                log::error!("unexpected response {message:#?}");
+                tracing::error!("unexpected response {message:#?}");
                 return Err(JaError::UnexpectedResponse);
             }
         };


### PR DESCRIPTION
# Description:

Not the full implementation, just replacing `log` crate and `simple_logger` with tracing and tracing subscriber as a stepping stone.

- feat: log -> tracing
- feat: make connection have trace span
- feat: added more spans and updated examples to use env filter
- feat: added logs for jarouter
- feat: remove simple logger
- docs: updated readme to use tokio subscriber
