### PR TITLE
feat/better api

### DIFF
--- a/jarust/src/jaconnection.rs
+++ b/jarust/src/jaconnection.rs
@@ -20,6 +20,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 
+pub type JaResponseStream = mpsc::Receiver<JaResponse>;
+
 #[derive(Debug)]
 struct Shared {
     demux_abort_handle: AbortHandle,
@@ -30,7 +32,7 @@ struct Shared {
 struct Exclusive {
     router: JaRouter,
     transport_protocol: TransportProtocol,
-    receiver: mpsc::Receiver<JaResponse>,
+    receiver: JaResponseStream,
     sessions: HashMap<u64, WeakJaSession>,
     transaction_manager: TransactionManager,
 }
@@ -160,7 +162,7 @@ impl JaConnection {
         request
     }
 
-    pub(crate) async fn add_subroute(&self, end: &str) -> mpsc::Receiver<JaResponse> {
+    pub(crate) async fn add_subroute(&self, end: &str) -> JaResponseStream {
         self.inner
             .exclusive
             .lock()

--- a/jarust/src/jahandle.rs
+++ b/jarust/src/jahandle.rs
@@ -24,8 +24,8 @@ struct Shared {
 }
 
 struct Exclusive {
-    ack_receiver: mpsc::Receiver<JaResponse>,
-    result_receiver: mpsc::Receiver<JaResponse>,
+    ack_receiver: JaResponseStream,
+    result_receiver: JaResponseStream,
 }
 
 struct InnerHandle {
@@ -46,9 +46,9 @@ pub struct WeakJaHandle {
 impl JaHandle {
     pub(crate) fn new(
         session: JaSession,
-        mut receiver: mpsc::Receiver<JaResponse>,
+        mut receiver: JaResponseStream,
         id: u64,
-    ) -> (Self, mpsc::Receiver<JaResponse>) {
+    ) -> (Self, JaResponseStream) {
         let (ack_sender, ack_receiver) = mpsc::channel(CHANNEL_BUFFER_SIZE);
         let (result_sender, result_receiver) = mpsc::channel(CHANNEL_BUFFER_SIZE);
         let (event_sender, event_receiver) = mpsc::channel(CHANNEL_BUFFER_SIZE);

--- a/jarust/src/japlugin.rs
+++ b/jarust/src/japlugin.rs
@@ -1,9 +1,6 @@
-use crate::japrotocol::JaResponse;
 use crate::jatask::AbortHandle;
-use crate::prelude::JaHandle;
-use crate::prelude::JaResult;
+use crate::prelude::*;
 use async_trait::async_trait;
-use tokio::sync::mpsc;
 
 pub trait PluginTask {
     fn assign_aborts(&mut self, abort_handles: Vec<AbortHandle>);
@@ -12,5 +9,5 @@ pub trait PluginTask {
 
 #[async_trait]
 pub trait Attach {
-    async fn attach(&self, plugin_id: &str) -> JaResult<(JaHandle, mpsc::Receiver<JaResponse>)>;
+    async fn attach(&self, plugin_id: &str) -> JaResult<(JaHandle, JaResponseStream)>;
 }

--- a/jarust/src/jarouter.rs
+++ b/jarust/src/jarouter.rs
@@ -30,7 +30,7 @@ pub(crate) struct JaRouter {
 
 impl JaRouter {
     #[tracing::instrument(level = tracing::Level::TRACE)]
-    pub(crate) async fn new(root_path: &str) -> (Self, mpsc::Receiver<JaResponse>) {
+    pub(crate) async fn new(root_path: &str) -> (Self, JaResponseStream) {
         let shared = Shared {
             root_path: root_path.to_string(),
         };
@@ -48,7 +48,7 @@ impl JaRouter {
     }
 
     #[tracing::instrument(level = tracing::Level::TRACE, skip(self))]
-    async fn make_route(&mut self, path: &str) -> mpsc::Receiver<JaResponse> {
+    async fn make_route(&mut self, path: &str) -> JaResponseStream {
         let (tx, rx) = mpsc::channel(CHANNEL_BUFFER_SIZE);
         {
             self.inner
@@ -62,12 +62,12 @@ impl JaRouter {
         rx
     }
 
-    async fn make_root_route(&mut self) -> mpsc::Receiver<JaResponse> {
+    async fn make_root_route(&mut self) -> JaResponseStream {
         let path = self.inner.shared.root_path.clone();
         self.make_route(&path).await
     }
 
-    pub(crate) async fn add_subroute(&mut self, end: &str) -> mpsc::Receiver<JaResponse> {
+    pub(crate) async fn add_subroute(&mut self, end: &str) -> JaResponseStream {
         let path = &format!("{}/{}", self.inner.shared.root_path, end);
         self.make_route(path).await
     }

--- a/jarust/src/jasession.rs
+++ b/jarust/src/jasession.rs
@@ -27,7 +27,7 @@ pub struct Shared {
 
 #[derive(Debug)]
 pub struct Exclusive {
-    receiver: mpsc::Receiver<JaResponse>,
+    receiver: JaResponseStream,
     handles: HashMap<u64, WeakJaHandle>,
     abort_handle: Option<AbortHandle>,
 }
@@ -51,7 +51,7 @@ pub struct WeakJaSession {
 impl JaSession {
     pub async fn new(
         connection: JaConnection,
-        receiver: mpsc::Receiver<JaResponse>,
+        receiver: JaResponseStream,
         id: u64,
         ka_interval: u32,
     ) -> Self {
@@ -136,7 +136,7 @@ impl Drop for Exclusive {
 impl Attach for JaSession {
     /// Attach a plugin to the current session
     #[tracing::instrument(level = tracing::Level::TRACE, skip(self))]
-    async fn attach(&self, plugin_id: &str) -> JaResult<(JaHandle, mpsc::Receiver<JaResponse>)> {
+    async fn attach(&self, plugin_id: &str) -> JaResult<(JaHandle, JaResponseStream)> {
         tracing::info!("Attaching new handle");
 
         let request = json!({

--- a/jarust/src/jasession.rs
+++ b/jarust/src/jasession.rs
@@ -1,7 +1,6 @@
 use crate::jaconnection::JaConnection;
 use crate::jahandle::JaHandle;
 use crate::jahandle::WeakJaHandle;
-use crate::japrotocol::JaResponse;
 use crate::japrotocol::JaResponseProtocol;
 use crate::japrotocol::JaSessionRequestProtocol;
 use crate::japrotocol::JaSuccessProtocol;
@@ -15,7 +14,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Weak;
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio::time;
 

--- a/jarust/src/prelude.rs
+++ b/jarust/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::error::JaError;
 pub use crate::jaconfig::CHANNEL_BUFFER_SIZE;
+pub use crate::jaconnection::JaResponseStream;
 pub use crate::jahandle::JaHandle;
 pub use crate::japlugin::Attach;
 pub use crate::japlugin::PluginTask;

--- a/jarust/src/prelude.rs
+++ b/jarust/src/prelude.rs
@@ -7,5 +7,6 @@ pub use crate::japrotocol::JaResponse;
 pub use crate::jasession::JaSession;
 pub use crate::jatask;
 pub use crate::jatask::AbortHandle;
+pub use crate::transport::trans::MessageStream;
 
 pub type JaResult<T> = core::result::Result<T, JaError>;

--- a/jarust/src/transport/trans.rs
+++ b/jarust/src/transport/trans.rs
@@ -3,6 +3,8 @@ use async_trait::async_trait;
 use std::fmt::Debug;
 use tokio::sync::mpsc;
 
+pub type MessageStream = mpsc::Receiver<String>;
+
 #[async_trait]
 pub trait Transport: Debug + Send + Sync + 'static {
     /// Creates a new transport
@@ -11,7 +13,7 @@ pub trait Transport: Debug + Send + Sync + 'static {
         Self: Sized;
 
     /// Connect the transport with the server. Returns a channel receiver.
-    async fn connect(&mut self, uri: &str) -> JaResult<mpsc::Receiver<String>>;
+    async fn connect(&mut self, uri: &str) -> JaResult<MessageStream>;
 
     /// Send a message over the transport.
     async fn send(&mut self, data: &[u8]) -> JaResult<()>;
@@ -23,7 +25,7 @@ impl TransportProtocol {
     pub async fn connect(
         mut transport: impl Transport,
         uri: &str,
-    ) -> JaResult<(Self, mpsc::Receiver<String>)> {
+    ) -> JaResult<(Self, MessageStream)> {
         let rx = transport.connect(uri).await?;
         let transport = Self(Box::new(transport));
         Ok((transport, rx))

--- a/jarust/src/transport/wasm_web_socket.rs
+++ b/jarust/src/transport/wasm_web_socket.rs
@@ -12,7 +12,7 @@ impl Transport for WasmWsTransport {
         Self
     }
 
-    async fn connect(&mut self, _uri: &str) -> JaResult<mpsc::Receiver<String>> {
+    async fn connect(&mut self, _uri: &str) -> JaResult<MessageStream> {
         tracing::error!("WASM support is WIP!");
         todo!("WASM support is WIP!")
     }

--- a/jarust/src/transport/web_socket.rs
+++ b/jarust/src/transport/web_socket.rs
@@ -35,7 +35,7 @@ impl Transport for WebsocketTransport {
         }
     }
 
-    async fn connect(&mut self, uri: &str) -> JaResult<mpsc::Receiver<String>> {
+    async fn connect(&mut self, uri: &str) -> JaResult<MessageStream> {
         let mut request = uri.into_client_request()?;
         let headers = request.headers_mut();
         headers.insert("Sec-Websocket-Protocol", "janus-protocol".parse()?);

--- a/jarust/tests/mocks/mock_transport.rs
+++ b/jarust/tests/mocks/mock_transport.rs
@@ -17,7 +17,7 @@ impl MockServer {
 }
 
 pub struct MockTransport {
-    rx: Option<mpsc::Receiver<String>>,
+    rx: Option<MessageStream>,
     server: Option<MockServer>,
     abort_handle: Option<AbortHandle>,
 }
@@ -42,7 +42,7 @@ impl Transport for MockTransport {
         }
     }
 
-    async fn connect(&mut self, _: &str) -> JaResult<mpsc::Receiver<String>> {
+    async fn connect(&mut self, _: &str) -> JaResult<MessageStream> {
         let (tx, rx) = mpsc::channel(32);
 
         if let Some(mut receiver) = self.rx.take() {


### PR DESCRIPTION
- **feat: alias mpsc::Receiver<String> -> MessageStream**
- **feat: alias mpsc::Receiver<JaResponse> -> JaResponseStream**
- **chore: remove unused imports**

Doing this so we have a better visibility of the types and can be wrapped easily
