### PR TITLE
feat/jasession enablement

### DIFF
--- a/jarust/examples/raw_echotest.rs
+++ b/jarust/examples/raw_echotest.rs
@@ -22,8 +22,11 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
-    let session = connection.create(10, Duration::from_secs(10)).await?;
-    let (handle, mut event_receiver) = session.attach("janus.plugin.echotest", capacity).await?;
+    let timeout = Duration::from_secs(10);
+    let session = connection.create(10, capacity, timeout).await?;
+    let (handle, mut event_receiver) = session
+        .attach("janus.plugin.echotest", capacity, timeout)
+        .await?;
 
     handle
         .send_waiton_ack(

--- a/jarust/examples/secure_ws.rs
+++ b/jarust/examples/secure_ws.rs
@@ -34,8 +34,10 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("server info: {:#?}", connection.server_info(timeout).await?);
 
-    let session = connection.create(10, timeout).await?;
-    let (handle, mut event_receiver) = session.attach("janus.plugin.echotest", capacity).await?;
+    let session = connection.create(10, capacity, timeout).await?;
+    let (handle, mut event_receiver) = session
+        .attach("janus.plugin.echotest", capacity, timeout)
+        .await?;
 
     tokio::spawn(async move {
         let mut interval = time::interval(time::Duration::from_secs(2));

--- a/jarust/src/jaconnection.rs
+++ b/jarust/src/jaconnection.rs
@@ -90,7 +90,12 @@ impl JaConnection {
 
     /// Creates a new session with janus server.
     #[tracing::instrument(level = tracing::Level::TRACE, skip(self))]
-    pub async fn create(&mut self, ka_interval: u32, timeout: Duration) -> JaResult<JaSession> {
+    pub async fn create(
+        &mut self,
+        ka_interval: u32,
+        capacity: usize,
+        timeout: Duration,
+    ) -> JaResult<JaSession> {
         tracing::info!("Creating new session");
 
         let request = json!({
@@ -118,7 +123,8 @@ impl JaConnection {
 
         let channel = self.add_subroute(&format!("{session_id}")).await;
 
-        let session = JaSession::new(self.clone(), channel, session_id, ka_interval).await;
+        let session =
+            JaSession::new(self.clone(), channel, session_id, ka_interval, capacity).await;
         self.inner
             .exclusive
             .lock()

--- a/jarust/src/japlugin.rs
+++ b/jarust/src/japlugin.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use async_trait::async_trait;
 use jarust_rt::JaTask;
+use std::time::Duration;
 
 pub trait PluginTask {
     fn assign_task(&mut self, task: JaTask);
@@ -13,5 +14,6 @@ pub trait Attach {
         &self,
         plugin_id: &str,
         capacity: usize,
+        timeout: Duration,
     ) -> JaResult<(JaHandle, JaResponseStream)>;
 }

--- a/jarust/tests/connection.rs
+++ b/jarust/tests/connection.rs
@@ -62,7 +62,7 @@ mod tests {
         .unwrap();
 
         server.mock_send_to_client(&msg).await;
-        let session = connection.create(10, Duration::from_secs(10)).await;
+        let session = connection.create(10, 32, Duration::from_secs(10)).await;
 
         assert!(session.is_ok());
     }
@@ -99,7 +99,7 @@ mod tests {
         .unwrap();
 
         server.mock_send_to_client(&msg).await;
-        let session = connection.create(10, Duration::from_secs(10)).await;
+        let session = connection.create(10, 32, Duration::from_secs(10)).await;
 
         assert!(matches!(session.unwrap_err(), JaError::JanusError { .. }))
     }

--- a/jarust/tests/fixtures/mod.rs
+++ b/jarust/tests/fixtures/mod.rs
@@ -3,7 +3,7 @@
 pub const FIXTURE_SESSION_ID: u64 = 2;
 pub const FIXTURE_HANDLE_ID: u64 = 3;
 pub const FIXTURE_KA_INTERVAL: u32 = 10;
-pub const FIXTURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+pub const FIXTURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 pub const FIXTURE_CAPACITY: usize = 10;
 
 pub const FIXTURE_PLUGIN_ID: &str = "jarust.plugin.fixture";

--- a/jarust/tests/handle.rs
+++ b/jarust/tests/handle.rs
@@ -48,6 +48,7 @@ mod tests {
             MockSessionConfig {
                 session_id: FIXTURE_SESSION_ID,
                 ka_interval: FIXTURE_KA_INTERVAL,
+                capacity: FIXTURE_CAPACITY,
                 timeout: FIXTURE_TIMEOUT,
             },
             "mock-session-transaction",
@@ -64,6 +65,7 @@ mod tests {
                 handle_id: FIXTURE_HANDLE_ID,
                 plugin_id: FIXTURE_PLUGIN_ID.to_string(),
                 capacity: FIXTURE_CAPACITY,
+                timeout: FIXTURE_TIMEOUT,
             },
             "mock-handle-transaction",
         )

--- a/jarust/tests/handle.rs
+++ b/jarust/tests/handle.rs
@@ -72,7 +72,6 @@ mod tests {
         .await
         .unwrap();
 
-        // generator.next_transaction("mock-event-transaction");
         let event = serde_json::to_string(&JaResponse {
             janus: ResponseType::Event(JaHandleEvent::GenericEvent(GenericEvent::Detached)),
             transaction: Some("mock-event-transaction".to_string()),

--- a/jarust/tests/mocks/mock_handle.rs
+++ b/jarust/tests/mocks/mock_handle.rs
@@ -3,6 +3,7 @@ use jarust::japrotocol::JaData;
 use jarust::japrotocol::JaSuccessProtocol;
 use jarust::japrotocol::ResponseType;
 use jarust::prelude::*;
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 pub struct MockHandleConfig {
@@ -10,6 +11,7 @@ pub struct MockHandleConfig {
     pub handle_id: u64,
     pub plugin_id: String,
     pub capacity: usize,
+    pub timeout: Duration,
 }
 
 #[allow(dead_code)]
@@ -32,7 +34,9 @@ pub async fn mock_handle(
     })
     .unwrap();
     server.mock_send_to_client(&attachment_msg).await;
-    let (handle, stream) = session.attach(&config.plugin_id, config.capacity).await?;
+    let (handle, stream) = session
+        .attach(&config.plugin_id, config.capacity, config.timeout)
+        .await?;
 
     Ok((handle, stream))
 }

--- a/jarust/tests/mocks/mock_session.rs
+++ b/jarust/tests/mocks/mock_session.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 pub struct MockSessionConfig {
     pub session_id: u64,
     pub ka_interval: u32,
+    pub capacity: usize,
     pub timeout: Duration,
 }
 
@@ -33,7 +34,7 @@ pub async fn mock_session(
 
     server.mock_send_to_client(&msg).await;
     let session = connection
-        .create(config.ka_interval, config.timeout)
+        .create(config.ka_interval, config.capacity, config.timeout)
         .await?;
 
     Ok(session)

--- a/jarust/tests/session.rs
+++ b/jarust/tests/session.rs
@@ -45,6 +45,7 @@ mod tests {
                 session_id: FIXTURE_SESSION_ID,
                 ka_interval: FIXTURE_KA_INTERVAL,
                 timeout: FIXTURE_TIMEOUT,
+                capacity: FIXTURE_CAPACITY,
             },
             "mock-transaction",
         )
@@ -62,7 +63,9 @@ mod tests {
         })
         .unwrap();
         server.mock_send_to_client(&attachment_msg).await;
-        let result = session.attach("mock.plugin.test", FIXTURE_CAPACITY).await;
+        let result = session
+            .attach("mock.plugin.test", FIXTURE_CAPACITY, FIXTURE_TIMEOUT)
+            .await;
         assert!(result.is_ok());
     }
 
@@ -89,6 +92,7 @@ mod tests {
                 session_id: FIXTURE_SESSION_ID,
                 ka_interval: FIXTURE_KA_INTERVAL,
                 timeout: FIXTURE_TIMEOUT,
+                capacity: FIXTURE_CAPACITY,
             },
             "mock-transaction",
         )
@@ -110,7 +114,9 @@ mod tests {
         .unwrap();
 
         server.mock_send_to_client(&error).await;
-        let result = session.attach("mock.plugin.test", FIXTURE_CAPACITY).await;
+        let result = session
+            .attach("mock.plugin.test", FIXTURE_CAPACITY, FIXTURE_TIMEOUT)
+            .await;
         assert!(result.is_err());
     }
 }

--- a/jarust_plugins/examples/audio_bridge.rs
+++ b/jarust_plugins/examples/audio_bridge.rs
@@ -27,9 +27,11 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
-    let session = connection.create(10, timeout).await?;
+    let session = connection
+        .create(10, 16 /* Buffer size on this session only */, timeout)
+        .await?;
     let (handle, mut events) = session
-        .attach_audio_bridge(16 /* Buffer size on this handle only */)
+        .attach_audio_bridge(16 /* Buffer size on this handle only */, timeout)
         .await?;
 
     let create_room_rsp = handle.create_room(None, timeout).await?;

--- a/jarust_plugins/examples/echotest.rs
+++ b/jarust_plugins/examples/echotest.rs
@@ -28,8 +28,9 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
-    let session = connection.create(10, Duration::from_secs(10)).await?;
-    let (handle, mut event_receiver) = session.attach_echo_test(capacity).await?;
+    let timeout = Duration::from_secs(10);
+    let session = connection.create(10, capacity, timeout).await?;
+    let (handle, mut event_receiver) = session.attach_echo_test(capacity, timeout).await?;
 
     handle
         .start(StartOptions {

--- a/jarust_plugins/examples/echotest_start_with_establishment.rs
+++ b/jarust_plugins/examples/echotest_start_with_establishment.rs
@@ -31,8 +31,9 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
-    let session = connection.create(10, Duration::from_secs(10)).await?;
-    let (handle, mut event_receiver) = session.attach_echo_test(capacity).await?;
+    let timeout = Duration::from_secs(10);
+    let session = connection.create(10, capacity, timeout).await?;
+    let (handle, mut event_receiver) = session.attach_echo_test(capacity, timeout).await?;
 
     let rsp = handle
         .start_with_establishment(

--- a/jarust_plugins/src/audio_bridge/jahandle_ext.rs
+++ b/jarust_plugins/src/audio_bridge/jahandle_ext.rs
@@ -2,6 +2,7 @@ use super::events::PluginEvent;
 use super::handle::AudioBridgeHandle;
 use jarust::prelude::*;
 use std::ops::Deref;
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[async_trait::async_trait]
@@ -12,8 +13,11 @@ pub trait AudioBridge: Attach {
     async fn attach_audio_bridge(
         &self,
         capacity: usize,
+        timeout: Duration,
     ) -> JaResult<(Self::Handle, mpsc::UnboundedReceiver<Self::Event>)> {
-        let (handle, mut receiver) = self.attach("janus.plugin.audiobridge", capacity).await?;
+        let (handle, mut receiver) = self
+            .attach("janus.plugin.audiobridge", capacity, timeout)
+            .await?;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let task = jarust_rt::spawn(async move {
             while let Some(rsp) = receiver.recv().await {

--- a/jarust_plugins/src/echo_test/jahandle_ext.rs
+++ b/jarust_plugins/src/echo_test/jahandle_ext.rs
@@ -2,6 +2,7 @@ use super::events::PluginEvent;
 use super::handle::EchoTestHandle;
 use jarust::prelude::*;
 use std::ops::Deref;
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[async_trait::async_trait]
@@ -12,8 +13,11 @@ pub trait EchoTest: Attach {
     async fn attach_echo_test(
         &self,
         capacity: usize,
+        timeout: Duration,
     ) -> JaResult<(Self::Handle, mpsc::UnboundedReceiver<Self::Event>)> {
-        let (handle, mut receiver) = self.attach("janus.plugin.echotest", capacity).await?;
+        let (handle, mut receiver) = self
+            .attach("janus.plugin.echotest", capacity, timeout)
+            .await?;
         let (tx, rx) = mpsc::unbounded_channel();
         let task = jarust_rt::spawn(async move {
             while let Some(rsp) = receiver.recv().await {

--- a/jarust_plugins/src/video_room/jahandle_ext.rs
+++ b/jarust_plugins/src/video_room/jahandle_ext.rs
@@ -2,6 +2,7 @@ use super::events::PluginEvent;
 use super::handle::VideoRoomHandle;
 use jarust::prelude::*;
 use std::ops::Deref;
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[async_trait::async_trait]
@@ -12,8 +13,11 @@ pub trait VideoRoom: Attach {
     async fn attach_video_room(
         &self,
         capacity: usize,
+        timeout: Duration,
     ) -> JaResult<(Self::Handle, mpsc::UnboundedReceiver<Self::Event>)> {
-        let (handle, mut receiver) = self.attach("janus.plugin.videoroom", capacity).await?;
+        let (handle, mut receiver) = self
+            .attach("janus.plugin.videoroom", capacity, timeout)
+            .await?;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let task = jarust_rt::spawn(async move {
             while let Some(rsp) = receiver.recv().await {


### PR DESCRIPTION
- **feat: added rsp cache on jasession**
- **fix: updated plugins with core**
- **test: fixed broken tests**

This PR should enable the addition of more janus session-level messages like `destory`
