### PR TITLE
refactor/tidy up interface

### DIFF
--- a/jarust/examples/raw_echotest.rs
+++ b/jarust/examples/raw_echotest.rs
@@ -1,6 +1,8 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
 use jarust::japlugin::Attach;
+use jarust::params::AttachHandleParams;
+use jarust::params::CreateConnectionParams;
 use jarust::TransactionGenerationStrategy;
 use serde_json::json;
 use std::time::Duration;
@@ -23,9 +25,19 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
     let timeout = Duration::from_secs(10);
-    let session = connection.create(10, capacity, timeout).await?;
+    let session = connection
+        .create(CreateConnectionParams {
+            ka_interval: 10,
+            capacity,
+            timeout,
+        })
+        .await?;
     let (handle, mut event_receiver) = session
-        .attach("janus.plugin.echotest", capacity, timeout)
+        .attach(AttachHandleParams {
+            plugin_id: "janus.plugin.echotest".to_string(),
+            capacity,
+            timeout,
+        })
         .await?;
 
     handle

--- a/jarust/examples/secure_ws.rs
+++ b/jarust/examples/secure_ws.rs
@@ -4,6 +4,8 @@ use jarust::japlugin::Attach;
 use jarust::japrotocol::EstablishmentProtocol;
 use jarust::japrotocol::Jsep;
 use jarust::japrotocol::JsepType;
+use jarust::params::AttachHandleParams;
+use jarust::params::CreateConnectionParams;
 use jarust::TransactionGenerationStrategy;
 use serde_json::json;
 use std::path::Path;
@@ -34,9 +36,19 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("server info: {:#?}", connection.server_info(timeout).await?);
 
-    let session = connection.create(10, capacity, timeout).await?;
+    let session = connection
+        .create(CreateConnectionParams {
+            ka_interval: 10,
+            capacity,
+            timeout,
+        })
+        .await?;
     let (handle, mut event_receiver) = session
-        .attach("janus.plugin.echotest", capacity, timeout)
+        .attach(AttachHandleParams {
+            plugin_id: "janus.plugin.echotest".to_string(),
+            capacity,
+            timeout,
+        })
         .await?;
 
     tokio::spawn(async move {

--- a/jarust/src/jaconnection.rs
+++ b/jarust/src/jaconnection.rs
@@ -127,6 +127,7 @@ impl JaConnection {
             params.capacity,
         )
         .await;
+
         self.inner
             .exclusive
             .lock()

--- a/jarust/src/japlugin.rs
+++ b/jarust/src/japlugin.rs
@@ -1,7 +1,7 @@
+use crate::params::AttachHandleParams;
 use crate::prelude::*;
 use async_trait::async_trait;
 use jarust_rt::JaTask;
-use std::time::Duration;
 
 pub trait PluginTask {
     fn assign_task(&mut self, task: JaTask);
@@ -10,10 +10,5 @@ pub trait PluginTask {
 
 #[async_trait]
 pub trait Attach {
-    async fn attach(
-        &self,
-        plugin_id: &str,
-        capacity: usize,
-        timeout: Duration,
-    ) -> JaResult<(JaHandle, JaResponseStream)>;
+    async fn attach(&self, params: AttachHandleParams) -> JaResult<(JaHandle, JaResponseStream)>;
 }

--- a/jarust/src/lib.rs
+++ b/jarust/src/lib.rs
@@ -5,6 +5,7 @@ pub mod jahandle;
 pub mod japlugin;
 pub mod japrotocol;
 pub mod jasession;
+pub mod params;
 pub mod prelude;
 pub mod respones;
 

--- a/jarust/src/params.rs
+++ b/jarust/src/params.rs
@@ -9,3 +9,13 @@ pub struct CreateConnectionParams {
     /// Request timeout
     pub timeout: Duration,
 }
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct AttachHandleParams {
+    /// Janus plugin identifier
+    pub plugin_id: String,
+    /// Handle buffer capacity
+    pub capacity: usize,
+    /// Request timeout
+    pub timeout: Duration,
+}

--- a/jarust/src/params.rs
+++ b/jarust/src/params.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 pub struct CreateConnectionParams {
     /// Keep alive interval in seconds
     pub ka_interval: u32,
-    /// Buffer capacity
+    /// Circular buffer capacity
     pub capacity: usize,
     /// Request timeout
     pub timeout: Duration,
@@ -14,7 +14,7 @@ pub struct CreateConnectionParams {
 pub struct AttachHandleParams {
     /// Janus plugin identifier
     pub plugin_id: String,
-    /// Handle buffer capacity
+    /// Circular buffer capacity
     pub capacity: usize,
     /// Request timeout
     pub timeout: Duration,

--- a/jarust/src/params.rs
+++ b/jarust/src/params.rs
@@ -1,0 +1,11 @@
+use std::time::Duration;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct CreateConnectionParams {
+    /// Keep alive interval in seconds
+    pub ka_interval: u32,
+    /// Buffer capacity
+    pub capacity: usize,
+    /// Request timeout
+    pub timeout: Duration,
+}

--- a/jarust/tests/connection.rs
+++ b/jarust/tests/connection.rs
@@ -17,6 +17,7 @@ mod tests {
     use jarust::japrotocol::JaResponse;
     use jarust::japrotocol::JaSuccessProtocol;
     use jarust::japrotocol::ResponseType;
+    use jarust::params::CreateConnectionParams;
     use jarust_transport::trans::TransportProtocol;
     use std::time::Duration;
 
@@ -62,7 +63,13 @@ mod tests {
         .unwrap();
 
         server.mock_send_to_client(&msg).await;
-        let session = connection.create(10, 32, Duration::from_secs(10)).await;
+        let session = connection
+            .create(CreateConnectionParams {
+                ka_interval: 10,
+                capacity: 32,
+                timeout: Duration::from_secs(10),
+            })
+            .await;
 
         assert!(session.is_ok());
     }
@@ -99,7 +106,13 @@ mod tests {
         .unwrap();
 
         server.mock_send_to_client(&msg).await;
-        let session = connection.create(10, 32, Duration::from_secs(10)).await;
+        let session = connection
+            .create(CreateConnectionParams {
+                ka_interval: 10,
+                capacity: 32,
+                timeout: Duration::from_secs(10),
+            })
+            .await;
 
         assert!(matches!(session.unwrap_err(), JaError::JanusError { .. }))
     }

--- a/jarust/tests/mocks/mock_handle.rs
+++ b/jarust/tests/mocks/mock_handle.rs
@@ -2,6 +2,7 @@ use super::mock_transport::MockServer;
 use jarust::japrotocol::JaData;
 use jarust::japrotocol::JaSuccessProtocol;
 use jarust::japrotocol::ResponseType;
+use jarust::params::AttachHandleParams;
 use jarust::prelude::*;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -35,7 +36,11 @@ pub async fn mock_handle(
     .unwrap();
     server.mock_send_to_client(&attachment_msg).await;
     let (handle, stream) = session
-        .attach(&config.plugin_id, config.capacity, config.timeout)
+        .attach(AttachHandleParams {
+            plugin_id: config.plugin_id,
+            capacity: config.capacity,
+            timeout: config.timeout,
+        })
         .await?;
 
     Ok((handle, stream))

--- a/jarust/tests/mocks/mock_session.rs
+++ b/jarust/tests/mocks/mock_session.rs
@@ -3,6 +3,7 @@ use jarust::jaconnection::JaConnection;
 use jarust::japrotocol::JaData;
 use jarust::japrotocol::JaSuccessProtocol;
 use jarust::japrotocol::ResponseType;
+use jarust::params::CreateConnectionParams;
 use jarust::prelude::*;
 use std::time::Duration;
 
@@ -34,7 +35,11 @@ pub async fn mock_session(
 
     server.mock_send_to_client(&msg).await;
     let session = connection
-        .create(config.ka_interval, config.capacity, config.timeout)
+        .create(CreateConnectionParams {
+            ka_interval: config.ka_interval,
+            capacity: config.capacity,
+            timeout: config.timeout,
+        })
         .await?;
 
     Ok(session)

--- a/jarust/tests/session.rs
+++ b/jarust/tests/session.rs
@@ -22,6 +22,7 @@ mod tests {
     use jarust::japrotocol::JaResponse;
     use jarust::japrotocol::JaSuccessProtocol;
     use jarust::japrotocol::ResponseType;
+    use jarust::params::AttachHandleParams;
 
     #[tokio::test]
     async fn it_successfully_attach_to_handle() {
@@ -68,7 +69,11 @@ mod tests {
         generator.next_transaction("mock-attach-plugin-transaction");
         // no need for assertion, if unwrap fails the test will fail
         let _ = session
-            .attach("mock.plugin.test", FIXTURE_CAPACITY, FIXTURE_TIMEOUT)
+            .attach(AttachHandleParams {
+                plugin_id: "mock.plugin.test".to_string(),
+                capacity: FIXTURE_CAPACITY,
+                timeout: FIXTURE_TIMEOUT,
+            })
             .await
             .unwrap();
     }
@@ -120,7 +125,11 @@ mod tests {
         server.mock_send_to_client(&error).await;
         generator.next_transaction("mock-attach-plugin-transaction");
         let result = session
-            .attach("mock.plugin.test", FIXTURE_CAPACITY, FIXTURE_TIMEOUT)
+            .attach(AttachHandleParams {
+                plugin_id: "mock.plugin.test".to_string(),
+                capacity: FIXTURE_CAPACITY,
+                timeout: FIXTURE_TIMEOUT,
+            })
             .await;
         assert!(matches!(
             result,

--- a/jarust_plugins/examples/audio_bridge.rs
+++ b/jarust_plugins/examples/audio_bridge.rs
@@ -1,8 +1,10 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
+use jarust::params::CreateConnectionParams;
 use jarust::TransactionGenerationStrategy;
 use jarust_plugins::audio_bridge::jahandle_ext::AudioBridge;
 use jarust_plugins::audio_bridge::msg_opitons::MuteOptions;
+use jarust_plugins::AttachPluginParams;
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
 
@@ -27,11 +29,16 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
+    let capacity = 10;
     let session = connection
-        .create(10, 16 /* Buffer size on this session only */, timeout)
+        .create(CreateConnectionParams {
+            ka_interval: 10,
+            capacity,
+            timeout,
+        })
         .await?;
     let (handle, mut events) = session
-        .attach_audio_bridge(16 /* Buffer size on this handle only */, timeout)
+        .attach_audio_bridge(AttachPluginParams { capacity, timeout })
         .await?;
 
     let create_room_rsp = handle.create_room(None, timeout).await?;

--- a/jarust_plugins/examples/echotest.rs
+++ b/jarust_plugins/examples/echotest.rs
@@ -1,10 +1,12 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::TransportType;
+use jarust::params::CreateConnectionParams;
 use jarust::TransactionGenerationStrategy;
 use jarust_plugins::echo_test::events::EchoTestEvent;
 use jarust_plugins::echo_test::events::PluginEvent;
 use jarust_plugins::echo_test::jahandle_ext::EchoTest;
 use jarust_plugins::echo_test::msg_options::StartOptions;
+use jarust_plugins::AttachPluginParams;
 use std::path::Path;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
@@ -29,8 +31,16 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
     let timeout = Duration::from_secs(10);
-    let session = connection.create(10, capacity, timeout).await?;
-    let (handle, mut event_receiver) = session.attach_echo_test(capacity, timeout).await?;
+    let session = connection
+        .create(CreateConnectionParams {
+            ka_interval: 10,
+            capacity,
+            timeout,
+        })
+        .await?;
+    let (handle, mut event_receiver) = session
+        .attach_echo_test(AttachPluginParams { capacity, timeout })
+        .await?;
 
     handle
         .start(StartOptions {

--- a/jarust_plugins/examples/echotest_start_with_establishment.rs
+++ b/jarust_plugins/examples/echotest_start_with_establishment.rs
@@ -3,11 +3,13 @@ use jarust::jaconfig::TransportType;
 use jarust::japrotocol::EstablishmentProtocol;
 use jarust::japrotocol::Jsep;
 use jarust::japrotocol::JsepType;
+use jarust::params::CreateConnectionParams;
 use jarust::TransactionGenerationStrategy;
 use jarust_plugins::echo_test::events::EchoTestEvent;
 use jarust_plugins::echo_test::events::PluginEvent;
 use jarust_plugins::echo_test::jahandle_ext::EchoTest;
 use jarust_plugins::echo_test::msg_options::StartOptions;
+use jarust_plugins::AttachPluginParams;
 use std::path::Path;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
@@ -32,8 +34,16 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
     let timeout = Duration::from_secs(10);
-    let session = connection.create(10, capacity, timeout).await?;
-    let (handle, mut event_receiver) = session.attach_echo_test(capacity, timeout).await?;
+    let session = connection
+        .create(CreateConnectionParams {
+            ka_interval: 10,
+            capacity,
+            timeout,
+        })
+        .await?;
+    let (handle, mut event_receiver) = session
+        .attach_echo_test(AttachPluginParams { capacity, timeout })
+        .await?;
 
     let rsp = handle
         .start_with_establishment(

--- a/jarust_plugins/src/audio_bridge/jahandle_ext.rs
+++ b/jarust_plugins/src/audio_bridge/jahandle_ext.rs
@@ -1,8 +1,9 @@
 use super::events::PluginEvent;
 use super::handle::AudioBridgeHandle;
+use crate::AttachPluginParams;
+use jarust::params::AttachHandleParams;
 use jarust::prelude::*;
 use std::ops::Deref;
-use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[async_trait::async_trait]
@@ -12,11 +13,14 @@ pub trait AudioBridge: Attach {
 
     async fn attach_audio_bridge(
         &self,
-        capacity: usize,
-        timeout: Duration,
+        params: AttachPluginParams,
     ) -> JaResult<(Self::Handle, mpsc::UnboundedReceiver<Self::Event>)> {
         let (handle, mut receiver) = self
-            .attach("janus.plugin.audiobridge", capacity, timeout)
+            .attach(AttachHandleParams {
+                plugin_id: "janus.plugin.audiobridge".to_string(),
+                capacity: params.capacity,
+                timeout: params.timeout,
+            })
             .await?;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let task = jarust_rt::spawn(async move {

--- a/jarust_plugins/src/common.rs
+++ b/jarust_plugins/src/common.rs
@@ -1,4 +1,6 @@
 pub struct AttachPluginParams {
+    /// Circular buffer capacity
     pub capacity: usize,
+    // Request timeout
     pub timeout: std::time::Duration,
 }

--- a/jarust_plugins/src/common.rs
+++ b/jarust_plugins/src/common.rs
@@ -1,0 +1,4 @@
+pub struct AttachPluginParams {
+    pub capacity: usize,
+    pub timeout: std::time::Duration,
+}

--- a/jarust_plugins/src/echo_test/jahandle_ext.rs
+++ b/jarust_plugins/src/echo_test/jahandle_ext.rs
@@ -1,8 +1,9 @@
 use super::events::PluginEvent;
 use super::handle::EchoTestHandle;
+use crate::AttachPluginParams;
+use jarust::params::AttachHandleParams;
 use jarust::prelude::*;
 use std::ops::Deref;
-use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[async_trait::async_trait]
@@ -12,11 +13,14 @@ pub trait EchoTest: Attach {
 
     async fn attach_echo_test(
         &self,
-        capacity: usize,
-        timeout: Duration,
+        params: AttachPluginParams,
     ) -> JaResult<(Self::Handle, mpsc::UnboundedReceiver<Self::Event>)> {
         let (handle, mut receiver) = self
-            .attach("janus.plugin.echotest", capacity, timeout)
+            .attach(AttachHandleParams {
+                plugin_id: "janus.plugin.echotest".to_string(),
+                capacity: params.capacity,
+                timeout: params.timeout,
+            })
             .await?;
         let (tx, rx) = mpsc::unbounded_channel();
         let task = jarust_rt::spawn(async move {

--- a/jarust_plugins/src/lib.rs
+++ b/jarust_plugins/src/lib.rs
@@ -6,3 +6,7 @@ pub mod audio_bridge;
 
 #[cfg(feature = "video_room")]
 pub mod video_room;
+
+pub mod common;
+
+pub use common::AttachPluginParams;

--- a/jarust_plugins/src/video_room/jahandle_ext.rs
+++ b/jarust_plugins/src/video_room/jahandle_ext.rs
@@ -1,8 +1,9 @@
 use super::events::PluginEvent;
 use super::handle::VideoRoomHandle;
+use crate::AttachPluginParams;
+use jarust::params::AttachHandleParams;
 use jarust::prelude::*;
 use std::ops::Deref;
-use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[async_trait::async_trait]
@@ -12,11 +13,14 @@ pub trait VideoRoom: Attach {
 
     async fn attach_video_room(
         &self,
-        capacity: usize,
-        timeout: Duration,
+        params: AttachPluginParams,
     ) -> JaResult<(Self::Handle, mpsc::UnboundedReceiver<Self::Event>)> {
         let (handle, mut receiver) = self
-            .attach("janus.plugin.videoroom", capacity, timeout)
+            .attach(AttachHandleParams {
+                plugin_id: "janus.plugin.echotest".to_string(),
+                capacity: params.capacity,
+                timeout: params.timeout,
+            })
             .await?;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let task = jarust_rt::spawn(async move {


### PR DESCRIPTION
- **refactor(core): create request now uses a struct param**
- **refactor(core): jasession functions now uses struct param**
- **refactor: attach plugin now uses struct**
- **docs: mention circular buffer for capacity**
