### PR TITLE
fix(plugins): remove `capacity` from AttachPluginParams

### DIFF
--- a/jarust_plugins/examples/audio_bridge.rs
+++ b/jarust_plugins/examples/audio_bridge.rs
@@ -29,7 +29,6 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
-    let capacity = 10;
     let session = connection
         .create(CreateConnectionParams {
             ka_interval: 10,
@@ -37,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
         })
         .await?;
     let (handle, mut events) = session
-        .attach_audio_bridge(AttachPluginParams { capacity, timeout })
+        .attach_audio_bridge(AttachPluginParams { timeout })
         .await?;
 
     let create_room_rsp = handle.create_room(None, timeout).await?;

--- a/jarust_plugins/examples/echotest.rs
+++ b/jarust_plugins/examples/echotest.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         })
         .await?;
     let (handle, mut event_receiver) = session
-        .attach_echo_test(AttachPluginParams { capacity, timeout })
+        .attach_echo_test(AttachPluginParams { timeout })
         .await?;
 
     handle

--- a/jarust_plugins/examples/echotest_start_with_establishment.rs
+++ b/jarust_plugins/examples/echotest_start_with_establishment.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
         })
         .await?;
     let (handle, mut event_receiver) = session
-        .attach_echo_test(AttachPluginParams { capacity, timeout })
+        .attach_echo_test(AttachPluginParams { timeout })
         .await?;
 
     let rsp = handle

--- a/jarust_plugins/examples/video_room.rs
+++ b/jarust_plugins/examples/video_room.rs
@@ -31,7 +31,6 @@ async fn main() -> anyhow::Result<()> {
         TransactionGenerationStrategy::Random,
     )
     .await?;
-    let capacity = 10;
     let session = connection
         .create(CreateConnectionParams {
             ka_interval: 10,
@@ -39,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         })
         .await?;
     let (handle, mut events) = session
-        .attach_video_room(AttachPluginParams { capacity, timeout })
+        .attach_video_room(AttachPluginParams { timeout })
         .await?;
 
     tokio::spawn(async move {

--- a/jarust_plugins/src/common.rs
+++ b/jarust_plugins/src/common.rs
@@ -3,8 +3,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 pub struct AttachPluginParams {
-    /// Circular buffer capacity
-    pub capacity: usize,
     // Request timeout
     pub timeout: std::time::Duration,
 }


### PR DESCRIPTION
The parameter is no longer needed for establishing a plugin connection as of #119