### PR TITLE
feat: add partial support for streaming info request

### DIFF
--- a/jarust_plugins/examples/streaming.rs
+++ b/jarust_plugins/examples/streaming.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
                 media: Some(Vec::from([StreamingRtpMedia {
                     media_type: "video".to_string(),
                     mid: "v".to_string(),
-                    port: 5005,
+                    port: 0,
                     pt: Some(100),
                     codec: Some("vp8".to_string()),
                     ..Default::default()
@@ -65,6 +65,9 @@ async fn main() -> anyhow::Result<()> {
 
     let mountpoints = handle.list(timeout).await?;
     tracing::info!("Mountpoints {:#?}", mountpoints);
+
+    let info = handle.info(JanusId::Uint(1337), None, timeout).await?;
+    tracing::info!("Info: {:#?}", info);
 
     handle
         .destroy_mountpoint(mountpoint_id, Default::default(), timeout)

--- a/jarust_plugins/src/streaming/handle.rs
+++ b/jarust_plugins/src/streaming/handle.rs
@@ -92,13 +92,13 @@ impl StreamingHandle {
         timeout: Duration,
     ) -> Result<MountpointInfo, jarust_interface::Error> {
         tracing::info!(plugin = "streaming", "Sending info");
-        let options = StreamingInfoOptions {
-            secret,
-            ..Default::default()
-        };
-        let mut message: Value = options.try_into()?;
-        message["request"] = "info".into();
-        message["id"] = mountpoint.try_into()?;
+        let mut message: Value = json!({
+            "request": "info",
+            "id": mountpoint,
+        });
+        if let Some(secret) = secret {
+            message["secret"] = secret.into();
+        }
         let response = self
             .handle
             .send_waiton_rsp::<MountpointInfoRsp>(message, timeout)

--- a/jarust_plugins/src/streaming/handle.rs
+++ b/jarust_plugins/src/streaming/handle.rs
@@ -84,8 +84,30 @@ impl StreamingHandle {
         Ok(response.list)
     }
 
+    #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
+    pub async fn info(
+        &self,
+        mountpoint: JanusId,
+        secret: Option<String>,
+        timeout: Duration,
+    ) -> Result<MountpointInfo, jarust_interface::Error> {
+        tracing::info!(plugin = "streaming", "Sending info");
+        let options = StreamingInfoOptions {
+            secret,
+            ..Default::default()
+        };
+        let mut message: Value = options.try_into()?;
+        message["request"] = "info".into();
+        message["id"] = mountpoint.try_into()?;
+        let response = self
+            .handle
+            .send_waiton_rsp::<MountpointInfoRsp>(message, timeout)
+            .await?;
+
+        Ok(response.info)
+    }
+
     // TODO:
-    // info
     // edit
     // enable
     // disable

--- a/jarust_plugins/src/streaming/msg_options.rs
+++ b/jarust_plugins/src/streaming/msg_options.rs
@@ -2,7 +2,7 @@ use crate::JanusId;
 use serde::Serialize;
 
 impl_tryfrom_serde_value!(
-    StreamingCreateOptions StreamingDestroyOptions
+    StreamingCreateOptions StreamingDestroyOptions StreamingInfoOptions
 );
 
 //
@@ -113,4 +113,15 @@ pub struct StreamingDestroyOptions {
     /// whether the mountpoint should be also removed from the config file, default=false
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permanent: Option<bool>,
+}
+
+//
+// Info Message
+//
+
+#[derive(Serialize, Default)]
+pub struct StreamingInfoOptions {
+    /// mountpoint secret, mandatory if configured to access sensitive info
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
 }

--- a/jarust_plugins/src/streaming/msg_options.rs
+++ b/jarust_plugins/src/streaming/msg_options.rs
@@ -2,7 +2,7 @@ use crate::JanusId;
 use serde::Serialize;
 
 impl_tryfrom_serde_value!(
-    StreamingCreateOptions StreamingDestroyOptions StreamingInfoOptions
+    StreamingCreateOptions StreamingDestroyOptions
 );
 
 //
@@ -113,15 +113,4 @@ pub struct StreamingDestroyOptions {
     /// whether the mountpoint should be also removed from the config file, default=false
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permanent: Option<bool>,
-}
-
-//
-// Info Message
-//
-
-#[derive(Serialize, Default)]
-pub struct StreamingInfoOptions {
-    /// mountpoint secret, mandatory if configured to access sensitive info
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub secret: Option<String>,
 }

--- a/jarust_plugins/src/streaming/responses.rs
+++ b/jarust_plugins/src/streaming/responses.rs
@@ -68,3 +68,71 @@ pub struct RtpMediaListed {
     pub msid: Option<String>,
     pub age_ms: Option<u64>,
 }
+
+// https://github.com/meetecho/janus-gateway/blob/v1.2.4/src/plugins/janus_streaming.c#L3172-L3309
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize)]
+pub struct MountpointInfoRsp {
+    pub info: MountpointInfo,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize)]
+pub struct MountpointInfo {
+    pub id: JanusId,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub metadata: Option<String>,
+    pub secret: Option<String>,
+    pub pin: Option<String>,
+    #[serde(default)]
+    pub is_private: bool,
+    pub enabled: bool,
+    pub viewers: Option<u64>,
+    /// <live|on demand>
+    #[serde(rename = "type")]
+    pub mountpoint_type: String,
+    // TODO: add support for non RTP live mountpoints
+    #[serde(default)]
+    pub rtsp: bool,
+    pub url: Option<String>,
+    pub rtsp_user: Option<String>,
+    pub rtsp_pwd: Option<String>,
+    pub rtsp_quirk: Option<bool>,
+    #[serde(default)]
+    pub srtp: bool,
+    #[serde(default)]
+    pub collision: i32,
+    #[serde(default)]
+    pub threads: i32,
+    pub host: Option<String>,
+    pub media: Vec<RtpMediaInfo>,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize)]
+pub struct RtpMediaInfo {
+    pub mindex: u64,
+    #[serde(rename = "type")]
+    pub media_type: String,
+    pub mid: String,
+    pub label: String,
+    pub msid: Option<String>,
+    pub pt: Option<u8>, // 0-127
+    pub codec: Option<String>,
+    pub rtpmap: Option<String>,
+    pub fmtp: Option<String>,
+    #[serde(default)]
+    pub videobufferkf: bool,
+    #[serde(default)]
+    pub videosimulcast: bool,
+    #[serde(default)]
+    pub videosvc: bool,
+    #[serde(default)]
+    pub skew_compensation: bool,
+    pub port: Option<u16>,
+    pub rtcpport: Option<u16>,
+    pub port2: Option<u16>,
+    pub port3: Option<u16>,
+    // <text|binary>
+    pub datatype: Option<String>,
+    pub age_ms: Option<u64>,
+    pub recording: Option<String>,
+}


### PR DESCRIPTION
only live RTP streaming source are supported.

I'm not confident enough in rust to handle responses from file based / on demand mountpoint types. I guess with some Enum + serde flatten it could be supported.