### PR TITLE
fix various typos

### DIFF
--- a/jarust/src/jahandle.rs
+++ b/jarust/src/jahandle.rs
@@ -77,14 +77,14 @@ impl JaHandle {
         Ok(res)
     }
 
-    /// Send a message and wait for ackowledgement
+    /// Send a message and wait for acknowledgement
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all, fields(session_id = self.inner.session_id, handle_id = self.inner.id))]
     pub async fn send_waiton_ack(
         &self,
         body: Value,
         timeout: Duration,
     ) -> Result<JaResponse, jarust_interface::Error> {
-        tracing::debug!("Sending message and waiting for ackowledgement");
+        tracing::debug!("Sending message and waiting for acknowledgement");
         let ack = self
             .inner
             .interface
@@ -98,7 +98,7 @@ impl JaHandle {
         Ok(ack)
     }
 
-    /// Send a message with a specific establishment protocol and wait for ackowledgement
+    /// Send a message with a specific establishment protocol and wait for acknowledgement
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all, fields(session_id = self.inner.session_id, handle_id = self.inner.id))]
     pub async fn send_waiton_ack_with_est(
         &self,
@@ -106,7 +106,7 @@ impl JaHandle {
         protocol: EstablishmentProtocol,
         timeout: Duration,
     ) -> Result<JaResponse, jarust_interface::Error> {
-        tracing::debug!("Sending message with establishment and waiting for ackowledgement");
+        tracing::debug!("Sending message with establishment and waiting for acknowledgement");
         let ack = self
             .inner
             .interface

--- a/jarust/src/jasession.rs
+++ b/jarust/src/jasession.rs
@@ -89,15 +89,15 @@ impl JaSession {
 }
 
 impl JaSession {
-    /// Destory the current session
+    /// Destroy the current session
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all, fields(session_id = self.inner.shared.id))]
-    pub async fn destory(&self, timeout: Duration) -> Result<(), jarust_interface::Error> {
+    pub async fn destroy(&self, timeout: Duration) -> Result<(), jarust_interface::Error> {
         tracing::info!("Destroying session");
         let session_id = self.inner.shared.id;
         self.inner
             .shared
             .interface
-            .destory(session_id, timeout)
+            .destroy(session_id, timeout)
             .await?;
         Ok(())
     }

--- a/jarust/tests/mocks/mock_interface.rs
+++ b/jarust/tests/mocks/mock_interface.rs
@@ -152,7 +152,7 @@ impl JanusInterface for MockInterface {
         todo!("Keep alive is not implemented");
     }
 
-    async fn destory(
+    async fn destroy(
         &self,
         _session_id: u64,
         _timeout: Duration,

--- a/jarust_interface/src/error.rs
+++ b/jarust_interface/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     InvalidJanusRequest { reason: String },
     #[error("Can't send data in closed channel")]
     SendError,
-    #[error("Received an unnexpected response")]
+    #[error("Received an unexpected response")]
     UnexpectedResponse,
     #[error("Janus error {{ code: {code}, reason: {reason}}}")]
     JanusError { code: u16, reason: String },

--- a/jarust_interface/src/janus_interface.rs
+++ b/jarust_interface/src/janus_interface.rs
@@ -62,7 +62,7 @@ pub trait JanusInterface: Debug + Send + Sync + 'static {
     async fn keep_alive(&self, session_id: u64, timeout: Duration) -> Result<(), Error>;
 
     /// Destroys the session.
-    async fn destory(&self, session_id: u64, timeout: Duration) -> Result<(), Error>;
+    async fn destroy(&self, session_id: u64, timeout: Duration) -> Result<(), Error>;
 
     /// Sends a one-shot message
     async fn fire_and_forget_msg(&self, message: HandleMessage) -> Result<(), Error>;
@@ -80,7 +80,7 @@ pub trait JanusInterface: Debug + Send + Sync + 'static {
     /// make this internal, and the public method that uses this one will have a generic return type.
     /// See [`JanusInterfaceImpl::send_msg_waiton_rsp`] for the public method.
     ///
-    /// Check this stack overflow asnwer for the technicalities:
+    /// Check this stack overflow answer for the technicalities:
     /// [Why are trait methods with generic type parameters are object unsafe](https://stackoverflow.com/questions/67767207/why-are-trait-methods-with-generic-type-parameters-object-unsafe)
     async fn internal_send_msg_waiton_rsp(
         &self,

--- a/jarust_interface/src/japrotocol.rs
+++ b/jarust_interface/src/japrotocol.rs
@@ -20,7 +20,7 @@ pub struct JaResponse {
 pub enum ResponseType {
     #[serde(rename = "error")]
     Error { error: ErrorResponse },
-    // Wrapped in a box so the entire enum isn't as large as this varient
+    // Wrapped in a box so the entire enum isn't as large as this variant
     // e.g: Ack that doesn't contain any data will have allocate the same space as ServerInfo
     #[serde(rename = "server_info")]
     ServerInfo(Box<ServerInfoRsp>),

--- a/jarust_interface/src/lib.rs
+++ b/jarust_interface/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Jarust Interface
 //!
-//! Jarust interface continas:
+//! Jarust interface contains:
 //!
 //! - Transport abstraction, you can use the built-in WebSocket interface, restful interface, or bring your own.
 //! - Transaction generation abstraction, you can use the built-in transaction generator or bring your own.

--- a/jarust_interface/src/respones.rs
+++ b/jarust_interface/src/respones.rs
@@ -25,7 +25,7 @@ pub struct ServerInfoRsp {
     pub ipv6: bool,
     pub ice_lite: bool,
     pub ice_tcp: bool,
-    pub ice_nomination: String, /* could be enum when we know the varients */
+    pub ice_nomination: String, /* could be enum when we know the variants */
     pub ice_keepalive_conncheck: bool,
     pub full_trickle: bool,
     pub mdns_enabled: bool,

--- a/jarust_interface/src/restful/restful_interface.rs
+++ b/jarust_interface/src/restful/restful_interface.rs
@@ -221,7 +221,7 @@ impl JanusInterface for RestfulInterface {
     }
 
     #[tracing::instrument(level = tracing::Level::TRACE, skip_all)]
-    async fn destory(&self, session_id: u64, timeout: Duration) -> Result<(), Error> {
+    async fn destroy(&self, session_id: u64, timeout: Duration) -> Result<(), Error> {
         let url = &self.inner.shared.url;
         let request = json!({
             "janus": "destroy"

--- a/jarust_interface/src/tgenerator.rs
+++ b/jarust_interface/src/tgenerator.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::ops::Deref;
 
-/// GenerateTransaction can be provided to an interface for generating messages transcations.
+/// GenerateTransaction can be provided to an interface for generating messages transactions.
 ///
 /// The more they're unique the better, especially when choosing with WebSockets interface as demultiplexing heavily relies on transaction ids.
 pub trait GenerateTransaction: Send + Sync + Debug + 'static {

--- a/jarust_interface/src/websocket/websocket_interface.rs
+++ b/jarust_interface/src/websocket/websocket_interface.rs
@@ -317,7 +317,7 @@ impl JanusInterface for WebSocketInterface {
     }
 
     #[tracing::instrument(level = tracing::Level::TRACE, skip_all)]
-    async fn destory(&self, session_id: u64, timeout: Duration) -> Result<(), Error> {
+    async fn destroy(&self, session_id: u64, timeout: Duration) -> Result<(), Error> {
         let request = json!({
             "janus": "destroy",
             "session_id": session_id

--- a/jarust_plugins/examples/audio_bridge.rs
+++ b/jarust_plugins/examples/audio_bridge.rs
@@ -3,7 +3,7 @@ use jarust::jaconfig::JanusAPI;
 use jarust::jaconnection::CreateConnectionParams;
 use jarust_interface::tgenerator::RandomTransactionGenerator;
 use jarust_plugins::audio_bridge::jahandle_ext::AudioBridge;
-use jarust_plugins::audio_bridge::msg_opitons::AudioBridgeMuteOptions;
+use jarust_plugins::audio_bridge::msg_options::AudioBridgeMuteOptions;
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
 

--- a/jarust_plugins/examples/video_room.rs
+++ b/jarust_plugins/examples/video_room.rs
@@ -1,13 +1,13 @@
 use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::JanusAPI;
 use jarust::jaconnection::CreateConnectionParams;
-use jarust_plugins::video_room::jahandle_ext::VideoRoom;
-use jarust_plugins::video_room::msg_options::*;
-use jarust_plugins::JanusId;
 use jarust_interface::japrotocol::EstablishmentProtocol;
 use jarust_interface::japrotocol::Jsep;
 use jarust_interface::japrotocol::JsepType;
 use jarust_interface::tgenerator::RandomTransactionGenerator;
+use jarust_plugins::video_room::jahandle_ext::VideoRoom;
+use jarust_plugins::video_room::msg_options::*;
+use jarust_plugins::JanusId;
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
 

--- a/jarust_plugins/src/audio_bridge/handle.rs
+++ b/jarust_plugins/src/audio_bridge/handle.rs
@@ -1,14 +1,14 @@
-use super::msg_opitons::AudioBridgeAllowedOptions;
-use super::msg_opitons::AudioBridgeChangeRoomOptions;
-use super::msg_opitons::AudioBridgeConfigureOptions;
-use super::msg_opitons::AudioBridgeCreateRoomOptions;
-use super::msg_opitons::AudioBridgeDestroyRoomMsg;
-use super::msg_opitons::AudioBridgeEditRoomOptions;
-use super::msg_opitons::AudioBridgeJoinRoomOptions;
-use super::msg_opitons::AudioBridgeKickAllOptions;
-use super::msg_opitons::AudioBridgeKickOptions;
-use super::msg_opitons::AudioBridgeMuteOptions;
-use super::msg_opitons::AudioBridgeMuteRoomOptions;
+use super::msg_options::AudioBridgeAllowedOptions;
+use super::msg_options::AudioBridgeChangeRoomOptions;
+use super::msg_options::AudioBridgeConfigureOptions;
+use super::msg_options::AudioBridgeCreateRoomOptions;
+use super::msg_options::AudioBridgeDestroyRoomMsg;
+use super::msg_options::AudioBridgeEditRoomOptions;
+use super::msg_options::AudioBridgeJoinRoomOptions;
+use super::msg_options::AudioBridgeKickAllOptions;
+use super::msg_options::AudioBridgeKickOptions;
+use super::msg_options::AudioBridgeMuteOptions;
+use super::msg_options::AudioBridgeMuteRoomOptions;
 use super::responses::AudioBridgeAllowedRsp;
 use super::responses::AudioBridgeExistsRoomRsp;
 use super::responses::AudioBridgeListParticipantsRsp;
@@ -96,7 +96,7 @@ impl AudioBridgeHandle {
         options: AudioBridgeDestroyRoomMsg,
         timeout: Duration,
     ) -> Result<AudioBridgeRoomDestroyedRsp, jarust_interface::Error> {
-        tracing::info!(plugin = "audiobridge", "Sending destory room");
+        tracing::info!(plugin = "audiobridge", "Sending destroy room");
         let mut message: Value = options.try_into()?;
         message["request"] = "destroy".into();
         message["room"] = room.try_into()?;
@@ -274,7 +274,7 @@ impl AudioBridgeHandle {
         self.handle.fire_and_forget(message).await
     }
 
-    /// Kicks all pariticpants out of a room
+    /// Kicks all participants out of a room
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn kick_all(
         &self,

--- a/jarust_plugins/src/audio_bridge/mod.rs
+++ b/jarust_plugins/src/audio_bridge/mod.rs
@@ -2,5 +2,5 @@ pub mod common;
 pub mod events;
 pub mod handle;
 pub mod jahandle_ext;
-pub mod msg_opitons;
+pub mod msg_options;
 pub mod responses;

--- a/jarust_plugins/src/audio_bridge/msg_options.rs
+++ b/jarust_plugins/src/audio_bridge/msg_options.rs
@@ -235,8 +235,8 @@ pub struct AudioBridgeJoinRoomOptions {
     /// additional attributes in the request, unless it's needed for application related purposes (e.g., to start muted).
     ///
     /// Notice that this does have an impact on renegotiations, e.g., for ICE restarts or changes in the media direction.
-    /// As a policy, plugins in Janus tend to enforce the same negotiation pattern used to setup the PeerConnection i
-    /// nitially for renegotiations too, as it reduces the risk of issues like glare: this means that users will NOT be
+    /// As a policy, plugins in Janus tend to enforce the same negotiation pattern used to setup the PeerConnection
+    /// initially for renegotiations too, as it reduces the risk of issues like glare: this means that users will NOT be
     /// able to send an SDP offer to the AudioBridge plugin to update an existing PeerConnection, if that PeerConnection
     /// had previously been originated by a plugin offer instead. The plugin will treat this as an error.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/jarust_plugins/src/video_room/msg_options.rs
+++ b/jarust_plugins/src/video_room/msg_options.rs
@@ -438,11 +438,11 @@ pub struct VideoRoomPublishOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<String>,
 
-    /// if provided, overrided the room audio_level_average for this user
+    /// if provided, override the room audio_level_average for this user
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_level_average: Option<u64>,
 
-    /// if provided, overrided the room audio_active_packets for this user
+    /// if provided, override the room audio_active_packets for this user
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_active_packets: Option<u64>,
 

--- a/jarust_rt/src/tokio_rt.rs
+++ b/jarust_rt/src/tokio_rt.rs
@@ -28,7 +28,7 @@ impl JaTask {
 impl Drop for JaTask {
     #[tracing::instrument(level = tracing::Level::TRACE, skip_all, fields(task_name = self.task_name))]
     fn drop(&mut self) {
-        tracing::trace!("Droping task");
+        tracing::trace!("Dropping task");
         self.cancel();
     }
 }


### PR DESCRIPTION
Ahead of jarust 1.0 I thought that fixing typos in modules and methods would be a good idea (otherwise it would be a breaking change...), and I went a little bit further and fixed some more typos in comments as well.