### PR TITLE
refactor/stabalize audio bridge api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   janus-gateway:
     container_name: janus-dev-server

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -11,6 +11,9 @@ edition.workspace = true
 repository.workspace = true
 publish = false
 
+[lib]
+doctest = false
+
 [dev-dependencies]
 jarust = { version = "0.7.0", path = "../jarust" }
 jarust_interface = { version = "0.7.0", path = "../jarust_interface" }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -14,6 +14,9 @@ publish = false
 [lib]
 doctest = false
 
+[dependencies]
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
 [dev-dependencies]
 jarust = { version = "0.7.0", path = "../jarust" }
 jarust_interface = { version = "0.7.0", path = "../jarust_interface" }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -15,4 +15,5 @@ publish = false
 jarust = { version = "0.7.0", path = "../jarust" }
 jarust_interface = { version = "0.7.0", path = "../jarust_interface" }
 jarust_plugins = { version = "0.7.0", path = "../jarust_plugins" }
+rand = "0.8.5"
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,1 +1,11 @@
-// Empty, this is a test crate
+use tracing_subscriber::EnvFilter;
+
+/// For debuggin e2e tests
+pub fn init_tracing_subscriber() {
+    let env_filter = EnvFilter::from_default_env()
+        .add_directive("jarust=trace".parse().unwrap())
+        .add_directive("jarust_plugins=trace".parse().unwrap())
+        .add_directive("jarust_interface=trace".parse().unwrap())
+        .add_directive("jarust_rt=trace".parse().unwrap());
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+}

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -12,84 +12,144 @@ use jarust_plugins::JanusId;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 
+// Allowing unused labels so we can use labels to have named blocks for test cases
+// I feel it's better than comments
+#[allow(unused_labels)]
 #[tokio::test]
 async fn room_crud_e2e() {
     let default_timeout = Duration::from_secs(4);
     let handle = make_audiobridge_attachment().await.0;
-
     let room_id = JanusId::Uint(rand::random());
 
-    let exists = handle
-        .exists(
-            AudioBridgeExistsParams {
-                room: room_id.clone(),
-            },
-            default_timeout,
-        )
-        .await
-        .expect("Failed to check if room exists");
-    assert_eq!(exists, false);
-
-    handle
-        .create_room(Some(room_id.clone()), default_timeout)
-        .await
-        .expect("Failed to create room");
-    let exists = handle
-        .exists(
-            AudioBridgeExistsParams {
-                room: room_id.clone(),
-            },
-            default_timeout,
-        )
-        .await
-        .expect("Failed to check if room exists");
-    assert_eq!(exists, true);
-
-    handle
-        .edit_room(
-            AudioBridgeEditParams {
-                room: room_id.clone(),
-                optional: AudioBridgeEditParamsOptional {
-                    new_description: Some("new description".to_string()),
-                    ..Default::default()
+    'before_creation: {
+        let exists = handle
+            .exists(
+                AudioBridgeExistsParams {
+                    room: room_id.clone(),
                 },
-            },
-            default_timeout,
-        )
-        .await
-        .expect("Failed to edit room");
+                default_timeout,
+            )
+            .await
+            .expect("Failed to check if room exists; before_creation");
+        assert_eq!(exists, false, "Room should not exist before creation");
+    }
 
-    let rooms = handle
-        .list_rooms(default_timeout)
-        .await
-        .expect("Failed to list rooms");
-    let edit_room = rooms
-        .iter()
-        .filter(|room| room.room == room_id)
-        .next()
-        .expect("Room not found");
-    assert_eq!(edit_room.description, "new description".to_string());
+    'creation: {
+        handle
+            .create_room(Some(room_id.clone()), default_timeout)
+            .await
+            .expect("Failed to create room; creation");
+        let exists = handle
+            .exists(
+                AudioBridgeExistsParams {
+                    room: room_id.clone(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to check if room exists; creation");
+        assert_eq!(exists, true, "Room should exist after creation");
 
-    handle
-        .destroy_room(
-            AudioBridgeDestoryParams {
-                room: room_id.clone(),
-                optional: Default::default(),
-            },
-            default_timeout,
-        )
-        .await
-        .expect("Failed to destroy room");
-    let exists = handle
-        .exists(
-            AudioBridgeExistsParams {
-                room: room_id.clone(),
-            },
-            default_timeout,
-        )
-        .await
-        .expect("Failed to check if room exists");
-    assert_eq!(exists, false);
+        let rooms = handle
+            .list_rooms(default_timeout)
+            .await
+            .expect("Failed to list rooms; creation");
+        assert_eq!(
+            rooms.iter().find(|room| room.room == room_id).is_some(),
+            true,
+            "Room should be visible when listing rooms"
+        );
+    }
+
+    'description_edit: {
+        handle
+            .edit_room(
+                AudioBridgeEditParams {
+                    room: room_id.clone(),
+                    optional: AudioBridgeEditParamsOptional {
+                        new_description: Some("new description".to_string()),
+                        ..Default::default()
+                    },
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to edit room; description_edit");
+
+        let rooms = handle
+            .list_rooms(default_timeout)
+            .await
+            .expect("Failed to list rooms; description_edit");
+        let edit_room = rooms
+            .iter()
+            .filter(|room| room.room == room_id)
+            .next()
+            .expect("Room not found; description_edit");
+        assert_eq!(
+            edit_room.description,
+            "new description".to_string(),
+            "Room description should be updated"
+        );
+    }
+
+    'private_edit: {
+        handle
+            .edit_room(
+                AudioBridgeEditParams {
+                    room: room_id.clone(),
+                    optional: AudioBridgeEditParamsOptional {
+                        new_is_private: Some(true),
+                        ..Default::default()
+                    },
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to edit room; private_edit");
+
+        let rooms = handle
+            .list_rooms(default_timeout)
+            .await
+            .expect("Failed to list rooms; private_edit");
+        assert_eq!(
+            rooms.iter().find(|room| room.room == room_id).is_some(),
+            false,
+            "Room should not be visible when listing rooms"
+        );
+        let exists = handle
+            .exists(
+                AudioBridgeExistsParams {
+                    room: room_id.clone(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to check if room exists; private_edit");
+        assert_eq!(exists, true, "Room should exist after setting to private");
+    }
+
+    'destory: {
+        handle
+            .destroy_room(
+                AudioBridgeDestoryParams {
+                    room: room_id.clone(),
+                    optional: Default::default(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to destroy room; destory");
+        let exists = handle
+            .exists(
+                AudioBridgeExistsParams {
+                    room: room_id.clone(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to check if room exists; destory");
+        assert_eq!(exists, false, "Room should not exist after destruction");
+    }
 }
 
 async fn make_audiobridge_attachment() -> (AudioBridgeHandle, UnboundedReceiver<PluginEvent>) {

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -1,0 +1,116 @@
+use jarust::jaconfig::JaConfig;
+use jarust::jaconfig::JanusAPI;
+use jarust_interface::tgenerator::RandomTransactionGenerator;
+use jarust_plugins::audio_bridge::events::PluginEvent;
+use jarust_plugins::audio_bridge::handle::AudioBridgeHandle;
+use jarust_plugins::audio_bridge::jahandle_ext::AudioBridge;
+use jarust_plugins::audio_bridge::params::AudioBridgeDestoryParams;
+use jarust_plugins::audio_bridge::params::AudioBridgeEditParams;
+use jarust_plugins::audio_bridge::params::AudioBridgeEditParamsOptional;
+use jarust_plugins::audio_bridge::params::AudioBridgeExistsParams;
+use jarust_plugins::JanusId;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+#[tokio::test]
+async fn room_crud_e2e() {
+    let default_timeout = Duration::from_secs(4);
+    let handle = make_audiobridge_attachment().await.0;
+
+    let room_id = JanusId::Uint(rand::random());
+
+    let exists = handle
+        .exists(
+            AudioBridgeExistsParams {
+                room: room_id.clone(),
+            },
+            default_timeout,
+        )
+        .await
+        .expect("Failed to check if room exists");
+    assert_eq!(exists, false);
+
+    handle
+        .create_room(Some(room_id.clone()), default_timeout)
+        .await
+        .expect("Failed to create room");
+    let exists = handle
+        .exists(
+            AudioBridgeExistsParams {
+                room: room_id.clone(),
+            },
+            default_timeout,
+        )
+        .await
+        .expect("Failed to check if room exists");
+    assert_eq!(exists, true);
+
+    handle
+        .edit_room(
+            AudioBridgeEditParams {
+                room: room_id.clone(),
+                optional: AudioBridgeEditParamsOptional {
+                    new_description: Some("new description".to_string()),
+                    ..Default::default()
+                },
+            },
+            default_timeout,
+        )
+        .await
+        .expect("Failed to edit room");
+
+    let rooms = handle
+        .list_rooms(default_timeout)
+        .await
+        .expect("Failed to list rooms");
+    let edit_room = rooms
+        .iter()
+        .filter(|room| room.room == room_id)
+        .next()
+        .expect("Room not found");
+    assert_eq!(edit_room.description, "new description".to_string());
+
+    handle
+        .destroy_room(
+            AudioBridgeDestoryParams {
+                room: room_id.clone(),
+                optional: Default::default(),
+            },
+            default_timeout,
+        )
+        .await
+        .expect("Failed to destroy room");
+    let exists = handle
+        .exists(
+            AudioBridgeExistsParams {
+                room: room_id.clone(),
+            },
+            default_timeout,
+        )
+        .await
+        .expect("Failed to check if room exists");
+    assert_eq!(exists, false);
+}
+
+async fn make_audiobridge_attachment() -> (AudioBridgeHandle, UnboundedReceiver<PluginEvent>) {
+    let config = JaConfig {
+        url: "ws://localhost:8188/ws".to_string(),
+        apisecret: None,
+        server_root: "janus".to_string(),
+        capacity: 32,
+    };
+    let mut connection = jarust::connect(config, JanusAPI::WebSocket, RandomTransactionGenerator)
+        .await
+        .expect("Failed to connect to server");
+    let timeout = Duration::from_secs(10);
+    let session = connection
+        .create_session(10, Duration::from_secs(10))
+        .await
+        .expect("Failed to create session");
+    let (handle, event_receiver) = session
+        .attach_audio_bridge(timeout)
+        .await
+        .expect("Failed to attach plugin");
+
+    (handle, event_receiver)
+}

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -24,5 +24,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0.89"
-tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/jarust_interface/Cargo.toml
+++ b/jarust_interface/Cargo.toml
@@ -10,6 +10,9 @@ categories.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 async-trait.workspace = true
 bytes.workspace = true

--- a/jarust_interface/Cargo.toml
+++ b/jarust_interface/Cargo.toml
@@ -28,6 +28,9 @@ tokio = { workspace = true, features = ["sync", "time", "rt"] }
 tracing.workspace = true
 uuid = { version = "1.10.0", features = ["fast-rng", "v4"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rustls = { version = "0.23.13", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }

--- a/jarust_plugins/examples/audio_bridge.rs
+++ b/jarust_plugins/examples/audio_bridge.rs
@@ -2,8 +2,9 @@ use jarust::jaconfig::JaConfig;
 use jarust::jaconfig::JanusAPI;
 use jarust_interface::tgenerator::RandomTransactionGenerator;
 use jarust_plugins::audio_bridge::jahandle_ext::AudioBridge;
-use jarust_plugins::audio_bridge::params::AudioBridgeJoinRoomParams;
-use jarust_plugins::audio_bridge::params::AudioBridgeJoinRoomParamsOptional;
+use jarust_plugins::audio_bridge::params::AudioBridgeJoinParams;
+use jarust_plugins::audio_bridge::params::AudioBridgeJoinParamsOptional;
+use jarust_plugins::audio_bridge::params::AudioBridgeListParticipantsParams;
 use jarust_plugins::audio_bridge::params::AudioBridgeMuteParams;
 use std::path::Path;
 use std::time::Duration;
@@ -47,9 +48,9 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Rooms {:#?}", rooms);
 
-    let join_room_params = AudioBridgeJoinRoomParams {
+    let join_room_params = AudioBridgeJoinParams {
         room: create_room_rsp.room.clone(),
-        optional: AudioBridgeJoinRoomParamsOptional {
+        optional: AudioBridgeJoinParamsOptional {
             display: Some("value".to_string()),
             ..Default::default()
         },
@@ -58,7 +59,12 @@ async fn main() -> anyhow::Result<()> {
     handle.join_room(join_room_params, None, timeout).await?;
 
     let list_participants_rsp = handle
-        .list_participants(create_room_rsp.room, timeout)
+        .list_participants(
+            AudioBridgeListParticipantsParams {
+                room: create_room_rsp.room,
+            },
+            timeout,
+        )
         .await?;
     tracing::info!(
         "Participants in room {:#?}: {:#?}",

--- a/jarust_plugins/src/audio_bridge/events.rs
+++ b/jarust_plugins/src/audio_bridge/events.rs
@@ -152,8 +152,8 @@ mod tests {
                     plugin: "janus.plugin.audiobridge".to_string(),
                     data: PluginInnerData::Data(json!({
                         "audiobridge": "joined",
-                        "room": 6846571539994870u64,
-                        "id": 7513785212278430u64,
+                        "room": 684657u32,
+                        "id": 751378u32,
                         "participants": []
                     })),
                 },
@@ -167,8 +167,8 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomJoined {
-                id: JanusId::Uint(7513785212278430),
-                room: JanusId::Uint(6846571539994870),
+                id: JanusId::Uint(751378u32),
+                room: JanusId::Uint(684657),
                 participants: vec![],
             })
         );
@@ -182,8 +182,8 @@ mod tests {
                     plugin: "janus.plugin.audiobridge".to_string(),
                     data: PluginInnerData::Data(json!({
                         "audiobridge": "joined",
-                        "room": 6846571539994870u64,
-                        "id": 7513785212278430u64,
+                        "room": 684657u32,
+                        "id": 751378u32,
                         "participants": []
                     })),
                 },
@@ -201,8 +201,8 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomJoinedWithEstabilshment {
-                id: JanusId::Uint(7513785212278430),
-                room: JanusId::Uint(6846571539994870),
+                id: JanusId::Uint(751378),
+                room: JanusId::Uint(684657),
                 participants: vec![],
                 estproto: EstProto::JSEP(Jsep {
                     jsep_type: JsepType::Answer,
@@ -221,8 +221,8 @@ mod tests {
                     plugin: "janus.plugin.audiobridge".to_string(),
                     data: PluginInnerData::Data(json!({
                         "audiobridge": "left",
-                        "room": 6846571539994870u64,
-                        "id": 7513785212278430u64
+                        "room": 684657u32,
+                        "id": 751378u32
                     })),
                 },
             }),
@@ -235,8 +235,8 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomLeft {
-                id: JanusId::Uint(7513785212278430),
-                room: JanusId::Uint(6846571539994870),
+                id: JanusId::Uint(751378),
+                room: JanusId::Uint(684657),
             })
         );
     }
@@ -249,8 +249,8 @@ mod tests {
                     plugin: "janus.plugin.audiobridge".to_string(),
                     data: PluginInnerData::Data(json!({
                         "audiobridge": "roomchanged",
-                        "room": 6168266702836626u64,
-                        "id": 3862697705388820u64,
+                        "room": 61682u32,
+                        "id": 38626u32,
                         "participants": []
                     })),
                 },
@@ -264,8 +264,8 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomChanged {
-                id: JanusId::Uint(3862697705388820),
-                room: JanusId::Uint(6168266702836626),
+                id: JanusId::Uint(38626),
+                room: JanusId::Uint(61682),
                 participants: vec![],
             })
         );

--- a/jarust_plugins/src/audio_bridge/handle.rs
+++ b/jarust_plugins/src/audio_bridge/handle.rs
@@ -65,7 +65,7 @@ impl AudioBridgeHandle {
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn edit_room(
         &self,
-        params: AudioBridgeCreateParams,
+        params: AudioBridgeEditParams,
         timeout: Duration,
     ) -> Result<AudioBridgeRoomEditedRsp, jarust_interface::Error> {
         tracing::info!(plugin = "audiobridge", "Sending edit room");

--- a/jarust_plugins/src/audio_bridge/params.rs
+++ b/jarust_plugins/src/audio_bridge/params.rs
@@ -2,7 +2,7 @@ use crate::JanusId;
 use serde::Serialize;
 
 make_dto!(
-    AudioBridgeCreateRoomParams,
+    AudioBridgeCreateParams,
     optional {
         /// Room identifier, chosen by plugin if missing
         room: JanusId,
@@ -42,6 +42,8 @@ make_dto!(
         record_dir: String,
         /// whether all participants in the room should be individually recorded to mjr files, default=false
         mjrs: bool,
+        /// /path/to/
+        mjrs_dir: String,
         /// whether participants should be allowed to join via plain RTP as well, default=false
         allow_rtp_participants: bool,
         /// non-hierarchical array of string group names to use to gat participants,
@@ -51,7 +53,7 @@ make_dto!(
 );
 
 make_dto!(
-    AudioBridgeEditRoomParams,
+    AudioBridgeEditParams,
     required { room: JanusId },
     optional {
         /// room secret, mandatory if configured
@@ -74,75 +76,45 @@ make_dto!(
 );
 
 make_dto!(
-    AudioBridgeDestoryRoomParams,
+    AudioBridgeDestoryParams,
     required { room: JanusId },
     optional {
+        /// room secret, mandatory if configured
         secret: String,
+        /// whether the room should be also removed from the config file, default=false
         permanent: bool
     }
 );
 
 make_dto!(
-    AudioBridgeJoinRoomParams,
+    AudioBridgeEnableRecordingParams,
     required { room: JanusId },
     optional {
-        /// Unique ID to assign to the participant, assigned by the plugin if missing
-        id: JanusId,
-        /// Group to assign to this participant (for forwarding purposes only; optional, mandatory if enabled in the room)
-        group: String,
-        /// Password required to join the room, if any.
-        pin: String,
-        /// Display name to have in the room
-        display: String,
-        /// Invitation token, in case the room has an ACL.
-        token: String,
-        /// Whether to start unmuted or muted, false by default
-        muted: bool,
-        /// Whether to start suspended or not, false by default
-        suspended: bool,
-        /// Whether room events should be paused, if the user is joining as suspended, false by default
-        pause_events: bool,
-        /// Codec to use, among opus (default), pcma (A-Law) or pcmu (mu-Law)"
-        codec: String,
-        /// Bitrate to use for the Opus stream in bps, default=0 (libopus decides)
-        bitrate: u64,
-        /// 0-10, Opus-related complexity to use, the higher the value, the better the quality (but more CPU); default is 4
-        quality: u64,
-        /// 0-20, a percentage of the expected loss (capped at 20%), only needed in case FEC is used,
-        /// default is 0 (FEC disabled even when negotiated) or the room default
-        expected_loss: u64,
-        /// Percent value, <100 reduces volume, >100 increases volume, default is 100 (no volume change)
-        volume: u64,
-        /// In case spatial audio is enabled for the room, panning of this participant (0=left, 50=center, 100=right)
-        spatial_position: String,
-        /// Room management password, if provided the user is an admin and can't be globally muted with `mute_room`
+        /// room secret; mandatory if configured
         secret: String,
-        /// If provided, overrides the room `audio_level_average` for this user.
-        audio_level_average: u64,
-        /// If provided, overrides the room audio_active_packets for this user.
-        audio_active_packets: u64,
-        /// Whether to record this user's contribution to a .mjr file (mixer not involved)
+        /// whether this room should be automatically recorded or not
         record: bool,
-        /// Basename of the file to record to, -audio.mjr will be added by the plugin; will be relative to mjrs_dir,
-        /// if configured in the room
-        filename: String,
-        /// A user can ask the plugin to generate an SDP offer first, to which they'd provide an SDP answer to.
-        /// This slightly changes the way the negotiation works within the context of the AudioBridge API, as some messages
-        /// may have to be used in a different way.
-        ///
-        /// This means that the user will receive a JSEP SDP offer as part of the related event: at this
-        /// point, the user needs to prepare to send a JSEP SDP answer and send it back to the plugin to complete the
-        /// negotiation. The user must use the `configure` request to provide this SDP answer: no need to provide
-        /// additional attributes in the request, unless it's needed for application related purposes (e.g., to start muted).
-        ///
-        /// Notice that this does have an impact on renegotiations, e.g., for ICE restarts or changes in the media direction.
-        /// As a policy, plugins in Janus tend to enforce the same negotiation pattern used to setup the PeerConnection i
-        /// nitially for renegotiations too, as it reduces the risk of issues like glare: this means that users will NOT be
-        /// able to send an SDP offer to the AudioBridge plugin to update an existing PeerConnection, if that PeerConnection
-        /// had previously been originated by a plugin offer instead. The plugin will treat this as an error.
-        generate_offer: bool
+        /// file where audio recording should be saved
+        record_file: String,
+        /// path where audio recording file should be saved
+        record_dir: String,
     }
 );
+
+make_dto!(
+    AudioBridgeEnableMjrsParams,
+    required { room: JanusId },
+    optional {
+        /// room secret; mandatory if configured
+        secret: String,
+        /// whether all participants in the room should be individually recorded to mjr files or not
+        mjrs: bool,
+        /// path where all MJR files should be saved to
+        mjrs_dir: String,
+    }
+);
+
+make_dto!(AudioBridgeExistsParams, required { room: JanusId });
 
 make_dto!(
     AudioBridgeAllowedParams,
@@ -168,6 +140,129 @@ pub enum AudioBridgeAllowAction {
 }
 
 make_dto!(
+    AudioBridgeKickParams,
+    required {
+        /// Participant ID
+        id: JanusId,
+        room: JanusId
+    },
+    optional {
+        /// Room secret, mandatory if configured
+        secret: String
+    }
+);
+
+make_dto!(
+    AudioBridgeKickAllParams,
+    required { room: JanusId },
+    optional {
+        /// Room secret, mandatory if configured
+        secret: String
+    }
+);
+
+make_dto!(
+    AudioBridgeListParticipantsParams,
+    required { room: JanusId }
+);
+
+make_dto!(
+    AudioBridgeJoinParams,
+    required { room: JanusId },
+    optional {
+        /// Unique ID to assign to the participant, assigned by the plugin if missing
+        id: JanusId,
+        /// Group to assign to this participant (for forwarding purposes only, mandatory if enabled in the room)
+        group: String,
+        /// Password required to join the room, if any.
+        pin: String,
+        /// Display name to have in the room
+        display: String,
+        /// Invitation token, in case the room has an ACL.
+        token: String,
+        /// Whether to start unmuted or muted, false by default
+        muted: bool,
+        /// Whether to start suspended or not, false by default
+        suspended: bool,
+        /// Whether room events should be paused, if the user is joining as suspended, false by default
+        pause_events: bool,
+        /// Codec to use, among opus (default), pcma (A-Law) or pcmu (mu-Law)"
+        codec: AudioBridgeCodec,
+        /// Bitrate to use for the Opus stream in bps, default=0 (libopus decides)
+        bitrate: u64,
+        /// 0-10, Opus-related complexity to use, the higher the value, the better the quality (but more CPU); default is 4
+        quality: u8,
+        /// 0-20, a percentage of the expected loss (capped at 20%), only needed in case FEC is used,
+        /// default is 0 (FEC disabled even when negotiated) or the room default
+        expected_loss: u8,
+        /// Percent value, <100 reduces volume, >100 increases volume, default is 100 (no volume change)
+        volume: u64,
+        /// In case spatial audio is enabled for the room, panning of this participant (0=left, 50=center, 100=right)
+        spatial_position: u8,
+        /// Room management password, if provided the user is an admin and can't be globally muted with `mute_room`
+        secret: String,
+        /// If provided, overrides the room `audio_level_average` for this user.
+        audio_level_average: u64,
+        /// If provided, overrides the room audio_active_packets for this user.
+        audio_active_packets: u64,
+        /// Whether to record this user's contribution to a .mjr file (mixer not involved)
+        record: bool,
+        /// Basename of the file to record to, -audio.mjr will be added by the plugin; will be relative to mjrs_dir,
+        /// if configured in the room
+        filename: String,
+        /// A user can ask the plugin to generate an SDP offer first, to which they'd provide an SDP answer to.
+        /// This slightly changes the way the negotiation works within the context of the AudioBridge API, as some messages
+        /// may have to be used in a different way.
+        ///
+        /// This means that the user will receive a JSEP SDP offer as part of the related event: at this
+        /// point, the user needs to prepare to send a JSEP SDP answer and send it back to the plugin to complete the
+        /// negotiation. The user must use the `configure` request to provide this SDP answer: no need to provide
+        /// additional attributes in the request, unless it's needed for application related purposes (e.g., to start muted).
+        ///
+        /// Notice that this does have an impact on renegotiations, e.g., for ICE restarts or changes in the media direction.
+        /// As a policy, plugins in Janus tend to enforce the same negotiation pattern used to setup the PeerConnection i
+        /// nitially for renegotiations too, as it reduces the risk of issues like glare: this means that users will NOT be
+        /// able to send an SDP offer to the AudioBridge plugin to update an existing PeerConnection, if that PeerConnection
+        /// had previously been originated by a plugin offer instead. The plugin will treat this as an error.
+        generate_offer: bool,
+        /// Notice that, while the AudioBridge assumes participants will exchange media via WebRTC, there's a less known
+        /// feature that allows you to use plain RTP to join an AudioBridge room instead. This functionality may be helpful
+        /// in case you want, e.g., SIP based endpoints to join an AudioBridge room, by crafting SDPs for the SIP dialogs
+        /// yourself using the info exchanged with the plugin. In order to do that, you keep on using the API to join as a
+        /// participant as explained above, but instead of negotiating a PeerConnection as you usually would
+        rtp: AudioBridgeRTP,
+    }
+);
+
+make_dto!(
+    AudioBridgeRTP,
+    required {
+        /// IP address you want media to be sent to
+        ip: String,
+        /// port you want media to be sent to
+        port: u16
+    },
+    optional {
+        /// payload type to use for RTP packets (only needed in case Opus is used, automatic for G.711)
+        payload_type: String,
+        /// ID of the audiolevel RTP extension, if used
+        audiolevel_ext: String,
+        /// whether FEC should be enabled for the Opus stream (only needed in case Opus is used)
+        fec: bool
+    }
+);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AudioBridgeCodec {
+    Opus,
+    /// A-Law
+    Pcma,
+    /// mu-Law
+    Pcmu,
+}
+
+make_dto!(
     AudioBridgeConfigureParams,
     optional {
         /// whether to unmute or mute
@@ -177,13 +272,13 @@ make_dto!(
         /// new bitrate to use for the Opus stream
         bitrate: u64,
         /// new Opus-related complexity to use (see "join" for more info)
-        quality: u64,
+        quality: u8,
         /// new value for the expected loss (see "join" for more info)
-        expected_loss: u64,
+        expected_loss: u8,
         /// new volume percent value (see "join" for more info)
         volume: u64,
         /// in case spatial audio is enabled for the room, new panning of this participant (0=left, 50=center, 100=right)
-        spatial_position: u64,
+        spatial_position: u8,
         /// whether denoising via RNNoise should be performed for this participant (default=room value)
         denoise: bool,
         /// whether to record this user's contribution to a .mjr file (mixer not involved)
@@ -213,22 +308,10 @@ make_dto!(
 make_dto!(
     AudioBridgeMuteRoomParams,
     required { room: JanusId },
-    optional { secret: String }
-);
-
-make_dto!(
-    AudioBridgeKickParams,
-    required {
-        id: JanusId,
-        room: JanusId
-    },
-    optional { secret: String }
-);
-
-make_dto!(
-    AudioBridgeKickAllParams,
-    required { room: JanusId },
-    optional { secret: String }
+    optional {
+        /// Room secret, mandatory if configured
+        secret: String
+    }
 );
 
 make_dto!(
@@ -237,20 +320,30 @@ make_dto!(
     optional {
         /// numeric ID of the room to move to
         id: JanusId,
-        /// whether to unmute or mute
-        muted: bool,
+        /// Password required to join the room, if any.
+        pin: String,
+        /// Group to assign to this participant (for forwarding purposes only, mandatory if enabled in the room)
+        group: String,
         /// new display name to have in the room (see "join" for more info)
         display: String,
+        /// invitation token, in case the new room has an ACL
+        token: String,
+        /// whether to unmute or mute
+        muted: bool,
+        /// whether to start suspended or not
+        suspend: bool,
+        /// whether room events should be paused, if the user is joining as suspended, false by default
+        pause_events: bool,
         /// new bitrate to use for the Opus stream
         bitrate: u64,
         /// new Opus-related complexity to use (see "join" for more info)
-        quality: u64,
+        quality: u8,
         /// new value for the expected loss (see "join" for more info)
-        expected_loss: u64,
+        expected_loss: u8,
         /// new volume percent value (see "join" for more info)
         volume: u64,
         /// in case spatial audio is enabled for the room, new panning of this participant (0=left, 50=center, 100=right)
-        spatial_position: u64,
+        spatial_position: u8,
         /// whether denoising via RNNoise should be performed for this participant (default=room value)
         denoise: bool
     }

--- a/jarust_plugins/src/common.rs
+++ b/jarust_plugins/src/common.rs
@@ -12,5 +12,5 @@ pub enum JanusId {
     /// String Identifier
     String(String),
     /// Unsigned Integer Identifier
-    Uint(u64),
+    Uint(u32),
 }

--- a/jarust_plugins/src/make_dto.rs
+++ b/jarust_plugins/src/make_dto.rs
@@ -51,14 +51,29 @@ macro_rules! make_dto {
         $(#[$main_attr:meta])* $main:ident,
         required { $(#[$rfield_attr:meta])* $rfield:ident: $rtype:ty }
     ) => {
-        compile_error!("Overkill, try passing the field directly instead of creating a DTO for it");
+        $(#[$main_attr])*
+        #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, serde::Serialize)]
+        pub struct $main {
+            $(#[$rfield_attr])*
+            pub $rfield: $rtype
+        }
+
+        impl_tryfrom_serde_value!($main);
     };
 
     (
         $(#[$main_attr:meta])* $main:ident,
         optional { $(#[$ofield_attr:meta])* $ofield:ident: $otype:ty }
     ) => {
-        compile_error!("Overkill, try passing the field directly instead of creating a DTO for it");
+        $(#[$main_attr])*
+        #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, serde::Serialize)]
+        pub struct $main {
+            $(#[$ofield_attr])*
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub $ofield: Option<$otype>
+        }
+
+        impl_tryfrom_serde_value!($main);
     };
 
     // Arguably overkill, we can pass 2 params to the function instead of constructing a DTO

--- a/jarust_plugins/src/streaming/events.rs
+++ b/jarust_plugins/src/streaming/events.rs
@@ -96,7 +96,7 @@ mod tests {
                     plugin: "janus.plugin.streaming".to_string(),
                     data: PluginInnerData::Data(json!({
                         "streaming": "created",
-                        "id": 6380744183070564u64,
+                        "id": 63807u32,
                         "type": "live",
                     })),
                 },
@@ -110,7 +110,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::StreamingEvent(StreamingEvent::MountpointCreated {
-                id: JanusId::Uint(6380744183070564u64),
+                id: JanusId::Uint(63807u32),
                 mountpoint_type: "live".to_string(),
             })
         );
@@ -124,7 +124,7 @@ mod tests {
                     plugin: "janus.plugin.streaming".to_string(),
                     data: PluginInnerData::Data(json!({
                         "streaming": "destroyed",
-                        "id": 6380744183070564u64,
+                        "id": 63807u32,
                     })),
                 },
             }),
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::StreamingEvent(StreamingEvent::MountpointDestroyed {
-                id: JanusId::Uint(6380744183070564u64),
+                id: JanusId::Uint(63807u32),
             })
         );
     }

--- a/jarust_plugins/src/video_room/events.rs
+++ b/jarust_plugins/src/video_room/events.rs
@@ -418,8 +418,8 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                         "videoroom": "joining",
-                        "room": 8812066423493633u64,
-                        "id": 6380744183070564u64,
+                        "room": 88120664u32,
+                        "id": 638074u32,
                         "display": "Joiner McJoinface"
                     })),
                 },
@@ -433,8 +433,8 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::RoomJoined {
-                id: JanusId::Uint(6380744183070564),
-                room: JanusId::Uint(8812066423493633u64),
+                id: JanusId::Uint(638074),
+                room: JanusId::Uint(88120664),
                 display: Some("Joiner McJoinface".to_string()),
             })
         );
@@ -448,8 +448,8 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                         "videoroom": "joining",
-                        "room": 8812066423493633u64,
-                        "id": 6380744183070564u64,
+                        "room": 8812063u32,
+                        "id": 8146468u32,
                         "display": "Joiner McJoinface"
                     })),
                 },
@@ -467,7 +467,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::RoomJoinedWithEst {
-                id: JanusId::Uint(6380744183070564u64),
+                id: JanusId::Uint(8146468u32),
                 display: Some("Joiner McJoinface".to_string()),
                 estproto: EstProto::JSEP(Jsep {
                     jsep_type: JsepType::Answer,
@@ -486,7 +486,7 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                         "videoroom": "destroyed",
-                        "room": 8812066423493633u64,
+                        "room": 8146468u32,
                     })),
                 },
             }),
@@ -499,7 +499,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::RoomDestroyed {
-                room: JanusId::Uint(8812066423493633u64),
+                room: JanusId::Uint(8146468u32),
             })
         )
     }
@@ -512,7 +512,7 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                         "videoroom": "publishers",
-                        "room": 8812066423493633u64,
+                        "room": 8146468u32,
                         "publishers": []
                     })),
                 },
@@ -526,7 +526,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::NewPublisher {
-                room: JanusId::Uint(8812066423493633u64),
+                room: JanusId::Uint(8146468u32),
                 publishers: vec![]
             })
         );
@@ -540,7 +540,7 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                        "videoroom": "joined",
-                       "room": 3966653182028680u64,
+                       "room": 8146468u32,
                        "description": "A brand new description!",
                        "id": 1337,
                        "private_id": 4113762326u64,
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::PublisherJoined {
-                room: JanusId::Uint(3966653182028680),
+                room: JanusId::Uint(8146468u32),
                 description: Some("A brand new description!".to_string()),
                 id: JanusId::Uint(1337),
                 private_id: 4113762326,
@@ -603,7 +603,7 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                        "videoroom": "event",
-                       "room": 8146468481724441u64,
+                       "room": 8146468u32,
                        "leaving": "ok"
                     })),
                 },
@@ -617,7 +617,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::LeftRoom {
-                room: JanusId::Uint(8146468481724441u64),
+                room: JanusId::Uint(8146468u32),
                 participant: JanusId::String("ok".to_string())
             })
         )
@@ -631,7 +631,7 @@ mod tests {
                     plugin: "janus.plugin.videoroom".to_string(),
                     data: PluginInnerData::Data(json!({
                        "videoroom": "event",
-                       "room": 1657434645789453u64,
+                       "room": 8146468u32,
                        "configured": "ok",
                        "audio_codec": "opus",
                        "video_codec": "h264",
@@ -668,7 +668,7 @@ mod tests {
         assert_eq!(
             event,
             PluginEvent::VideoRoomEvent(VideoRoomEvent::ConfiguredWithEst {
-                room: JanusId::Uint(1657434645789453u64),
+                room: JanusId::Uint(8146468u32),
                 audio_codec: Some("opus".to_string()),
                 video_codec: Some("h264".to_string()),
                 streams: vec![


### PR DESCRIPTION
- audiobridge api stabilization
- room crud e2e tests for audiobridge
- `make_dto` now can be used for single field structs