### PR TITLE
fix/session destory

### DIFF
--- a/e2e/tests/core.rs
+++ b/e2e/tests/core.rs
@@ -1,3 +1,4 @@
+use jarust::core::connect;
 use jarust::core::jaconfig::JaConfig;
 use jarust::core::jaconfig::JanusAPI;
 use jarust::core::prelude::Attach;
@@ -14,10 +15,9 @@ async fn it_websocket_core_tests() {
         server_root: "janus".to_string(),
         capacity: 32,
     };
-    let mut connection =
-        jarust::core::connect(config, JanusAPI::WebSocket, RandomTransactionGenerator)
-            .await
-            .unwrap();
+    let mut connection = connect(config, JanusAPI::WebSocket, RandomTransactionGenerator)
+        .await
+        .unwrap();
 
     'server_info: {
         let info = connection

--- a/e2e/tests/core.rs
+++ b/e2e/tests/core.rs
@@ -4,8 +4,10 @@ use jarust::core::prelude::Attach;
 use jarust::interface::tgenerator::RandomTransactionGenerator;
 use std::time::Duration;
 
+#[allow(unused_labels)]
 #[tokio::test]
 async fn it_websocket_core_tests() {
+    e2e::init_tracing_subscriber();
     let config = JaConfig {
         url: "ws://localhost:8188/ws".to_string(),
         apisecret: None,
@@ -17,11 +19,37 @@ async fn it_websocket_core_tests() {
             .await
             .unwrap();
 
-    let info = connection
-        .server_info(Duration::from_secs(5))
-        .await
-        .unwrap();
-    assert_eq!(info.server_name, "Jarust".to_string());
+    'server_info: {
+        let info = connection
+            .server_info(Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(
+            info.server_name,
+            "Jarust".to_string(),
+            "Server name should match the one in server_config/janus.cfg"
+        );
+    }
+
+    'destroyed_session: {
+        let session = connection
+            .create_session(10, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        session.destroy(Duration::from_secs(5)).await.unwrap();
+
+        let result = session
+            .attach("janus.plugin.echotest".to_string(), Duration::from_secs(5))
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(jarust::interface::error::Error::JanusError { code: _, reason: _ })
+            ),
+            "No such session after destroying it"
+        )
+    }
 
     let session = connection
         .create_session(10, Duration::from_secs(5))

--- a/jarust_interface/src/japrotocol.rs
+++ b/jarust_interface/src/japrotocol.rs
@@ -48,6 +48,8 @@ pub enum JaSuccessProtocol {
         #[serde(rename = "plugindata")]
         plugin_data: PluginData,
     },
+    #[serde(untagged)]
+    Empty {},
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]


### PR DESCRIPTION
- **fix: parse empty success body for success messages without body**
- **chore: import connect instead of stating the namespace**
