### PR TITLE
feat: added picking a runtime in jarust umbrella

### DIFF
--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -19,7 +19,7 @@ jarust_interface = { version = "0.8.0", path = "../jarust_interface", default-fe
 jarust_plugins = { version = "0.8.0", path = "../jarust_plugins", default-features = false }
 
 [features]
-default = ["use-native-tls"]
+default = ["use-native-tls", "tokio-rt"]
 
 # Plugins
 audio_bridge_plugin = ["jarust_plugins/audio_bridge"]
@@ -31,6 +31,13 @@ __plugin_expiremental = ["jarust_plugins/__experimental"]
 # Interface
 use-native-tls = ["jarust_interface/use-native-tls"]
 use-rustls = ["jarust_interface/use-rustls"]
+
+# Runtime
+tokio-rt = [
+    "jarust_core/tokio-rt",
+    "jarust_interface/tokio-rt",
+    "jarust_plugins/tokio-rt",
+]
 
 [dev-dependencies]
 anyhow = "1.0.93"

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-jarust_core = { version = "0.8.0", path = "../jarust_core" }
+jarust_core = { version = "0.8.0", path = "../jarust_core", default-features = false }
 jarust_interface = { version = "0.8.0", path = "../jarust_interface", default-features = false }
 jarust_plugins = { version = "0.8.0", path = "../jarust_plugins", default-features = false }
 
@@ -47,4 +47,3 @@ serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing.workspace = true
-jarust_plugins = { version = "0.8.0", path = "../jarust_plugins" }

--- a/jarust_core/Cargo.toml
+++ b/jarust_core/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 async-trait.workspace = true
-jarust_interface = { version = "0.8.0", path = "../jarust_interface" }
+jarust_interface = { version = "0.8.0", path = "../jarust_interface", default-features = false }
 jarust_rt = { version = "0.8.0", path = "../jarust_rt", default-features = false }
 serde_json.workspace = true
 serde.workspace = true
@@ -24,7 +24,7 @@ tracing.workspace = true
 
 [features]
 default = ["tokio-rt"]
-tokio-rt = ["jarust_rt/tokio-rt"]
+tokio-rt = ["jarust_rt/tokio-rt", "jarust_interface/tokio-rt"]
 
 [dev-dependencies]
 anyhow = "1.0.93"

--- a/jarust_core/Cargo.toml
+++ b/jarust_core/Cargo.toml
@@ -16,11 +16,15 @@ doctest = false
 [dependencies]
 async-trait.workspace = true
 jarust_interface = { version = "0.8.0", path = "../jarust_interface" }
-jarust_rt = { version = "0.8.0", path = "../jarust_rt" }
+jarust_rt = { version = "0.8.0", path = "../jarust_rt", default-features = false }
 serde_json.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
+
+[features]
+default = ["tokio-rt"]
+tokio-rt = ["jarust_rt/tokio-rt"]
 
 [dev-dependencies]
 anyhow = "1.0.93"

--- a/jarust_interface/Cargo.toml
+++ b/jarust_interface/Cargo.toml
@@ -18,7 +18,7 @@ async-trait.workspace = true
 bytes.workspace = true
 futures-util.workspace = true
 indexmap = "2.6.0"
-jarust_rt = { version = "0.8.0", path = "../jarust_rt" }
+jarust_rt = { version = "0.8.0", path = "../jarust_rt", default-features = false }
 rand = "0.8.5"
 reqwest = { version = "0.12.9", features = ["json"] }
 serde_json.workspace = true
@@ -27,9 +27,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
 tracing.workspace = true
 uuid = { version = "1.11.0", features = ["fast-rng", "v4"] }
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rustls = { version = "0.23.13", optional = true }
@@ -40,6 +37,10 @@ tokio-tungstenite = "0.24.0"
 getrandom = { version = "0.2.12", features = ["js"] }
 
 [features]
-default = ["use-native-tls"]
+default = ["use-native-tls", "tokio-rt"]
 use-native-tls = ["tokio-tungstenite/native-tls"]
 use-rustls = ["rustls", "rustls-native-certs", "tokio-tungstenite/__rustls-tls"]
+tokio-rt = ["jarust_rt/tokio-rt"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 async-trait.workspace = true
 jarust_core = { version = "0.8.0", path = "../jarust_core" }
 jarust_interface = { version = "0.8.0", path = "../jarust_interface" }
-jarust_rt = { version = "0.8.0", path = "../jarust_rt" }
+jarust_rt = { version = "0.8.0", path = "../jarust_rt", default-features = false }
 paste = "1.0.15"
 serde_json.workspace = true
 serde.workspace = true
@@ -25,7 +25,8 @@ tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 
 [features]
-default = ["echo_test", "audio_bridge", "video_room", "streaming"]
+default = ["tokio-rt", "echo_test", "audio_bridge", "video_room", "streaming"]
+tokio-rt = ["jarust_rt/tokio-rt"]
 echo_test = []
 audio_bridge = []
 video_room = []

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -15,8 +15,8 @@ doctest = false
 
 [dependencies]
 async-trait.workspace = true
-jarust_core = { version = "0.8.0", path = "../jarust_core" }
-jarust_interface = { version = "0.8.0", path = "../jarust_interface" }
+jarust_core = { version = "0.8.0", path = "../jarust_core", default-features = false }
+jarust_interface = { version = "0.8.0", path = "../jarust_interface", default-features = false }
 jarust_rt = { version = "0.8.0", path = "../jarust_rt", default-features = false }
 paste = "1.0.15"
 serde_json.workspace = true
@@ -26,7 +26,11 @@ tracing.workspace = true
 
 [features]
 default = ["tokio-rt", "echo_test", "audio_bridge", "video_room", "streaming"]
-tokio-rt = ["jarust_rt/tokio-rt"]
+tokio-rt = [
+    "jarust_rt/tokio-rt",
+    "jarust_interface/tokio-rt",
+    "jarust_core/tokio-rt",
+]
 echo_test = []
 audio_bridge = []
 video_room = []


### PR DESCRIPTION
Made the runtime a configurable feature that will downstream from jarust umbrella to the core, interface, and plugins