### PR TITLE
chore: actions-rs -> rust-toolchain actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,11 +54,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - run: |
           cargo publish -p jarust_rt --token ${CRATES_TOKEN}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo clippy
 
   test:
     name: Integration test
@@ -24,13 +20,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --exclude e2e
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --workspace --exclude e2e
 
   e2e:
     name: E2E tests
@@ -40,7 +31,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hoverkraft-tech/compose-action@v2.0.1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p e2e
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test -p e2e


### PR DESCRIPTION
Replaced deprecated `actions-rs` with `rust-toolchain`