### PR TITLE
test/audio bridge participants e2es

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 thiserror = "1.0.68"
 tokio = "1.41.1"
-tracing = "0.1.40"
+tracing = "0.1.41"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -20,6 +20,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 [dev-dependencies]
 rand = "0.8.5"
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
+tracing.workspace = true
 
 [dev-dependencies.jarust]
 path = "../jarust"

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -1,6 +1,8 @@
 use jarust::core::jaconfig::JaConfig;
 use jarust::core::jaconfig::JanusAPI;
 use jarust::interface::tgenerator::RandomTransactionGenerator;
+use jarust::plugins::audio_bridge::common::AudioBridgeParticipant;
+use jarust::plugins::audio_bridge::events::AudioBridgeEvent;
 use jarust::plugins::audio_bridge::events::PluginEvent;
 use jarust::plugins::audio_bridge::handle::AudioBridgeHandle;
 use jarust::plugins::audio_bridge::jahandle_ext::AudioBridge;
@@ -8,6 +10,8 @@ use jarust::plugins::audio_bridge::params::AudioBridgeDestroyParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeEditParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeEditParamsOptional;
 use jarust::plugins::audio_bridge::params::AudioBridgeExistsParams;
+use jarust::plugins::audio_bridge::params::AudioBridgeJoinParams;
+use jarust::plugins::audio_bridge::params::AudioBridgeMuteParams;
 use jarust::plugins::JanusId;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -80,7 +84,8 @@ async fn room_crud_e2e() {
             .await
             .expect("Failed to list rooms; description_edit");
         let edit_room = rooms
-            .iter().find(|room| room.room == room_id)
+            .iter()
+            .find(|room| room.room == room_id)
             .expect("Room not found; description_edit");
         assert_eq!(
             edit_room.description,
@@ -145,6 +150,225 @@ async fn room_crud_e2e() {
             .await
             .expect("Failed to check if room exists; destroy");
         assert!(!exists, "Room should not exist after destruction");
+    }
+}
+
+#[allow(unused_labels)]
+#[tokio::test]
+async fn participants_e2e() {
+    let default_timeout = Duration::from_secs(4);
+    let room_id = JanusId::Uint(rand::random::<u64>().into());
+    let admin = make_audiobridge_attachment().await.0;
+    let (alice_handle, mut alice_events) = make_audiobridge_attachment().await;
+    let (bob_handle, mut bob_events) = make_audiobridge_attachment().await;
+    let (eve_handle, mut eve_events) = make_audiobridge_attachment().await;
+
+    admin
+        .create_room(Some(room_id.clone()), default_timeout)
+        .await
+        .expect("Admin failed to create room; creation");
+
+    // Alice joins the room
+    let alice = {
+        alice_handle
+            .join_room(
+                AudioBridgeJoinParams {
+                    room: room_id.clone(),
+                    optional: Default::default(),
+                },
+                None,
+                default_timeout,
+            )
+            .await
+            .expect("Alice failed to join room");
+
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomJoined {
+            participants,
+            room,
+            id,
+        }) = alice_events
+            .recv()
+            .await
+            .expect("Eve failed to receive event")
+        else {
+            panic!("Eve received unexpected event")
+        };
+
+        assert_eq!(room, room_id, "Alice should join correct room");
+        assert_eq!(participants, vec![], "No participants should be in room");
+
+        AudioBridgeParticipant {
+            id,
+            display: None,
+            setup: false,
+            muted: false,
+            suspended: None,
+            talking: None,
+            spatial_position: None,
+        }
+    };
+
+    // Bob joins the room
+    let _bob = {
+        bob_handle
+            .join_room(
+                AudioBridgeJoinParams {
+                    room: room_id.clone(),
+                    optional: Default::default(),
+                },
+                None,
+                default_timeout,
+            )
+            .await
+            .expect("Bob failed to join room");
+
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomJoined {
+            participants,
+            room,
+            id,
+        }) = bob_events
+            .recv()
+            .await
+            .expect("Eve failed to receive event")
+        else {
+            panic!("Eve received unexpected event")
+        };
+
+        assert_eq!(room, room_id, "Bob should join correct room");
+        assert_eq!(
+            participants,
+            vec![alice.clone()],
+            "Only Alice should be in room"
+        );
+
+        AudioBridgeParticipant {
+            id,
+            display: None,
+            setup: false,
+            muted: false,
+            suspended: None,
+            talking: None,
+            spatial_position: None,
+        }
+    };
+
+    // Eve joins the room
+    let _eve = {
+        eve_handle
+            .join_room(
+                AudioBridgeJoinParams {
+                    room: room_id.clone(),
+                    optional: Default::default(),
+                },
+                None,
+                default_timeout,
+            )
+            .await
+            .expect("Eve failed to join room");
+
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::RoomJoined {
+            participants,
+            room,
+            id,
+        }) = eve_events
+            .recv()
+            .await
+            .expect("Eve failed to receive event")
+        else {
+            panic!("Eve received unexpected event")
+        };
+
+        assert_eq!(room, room_id, "Eve should join correct room");
+        assert_eq!(participants.len(), 2, "Alice and Bob should be in room");
+        assert_eq!(
+            participants.contains(&alice),
+            true,
+            "Alice should be in room"
+        );
+
+        AudioBridgeParticipant {
+            id,
+            display: None,
+            setup: false,
+            muted: false,
+            suspended: None,
+            talking: None,
+            spatial_position: None,
+        }
+    };
+
+    'mute_and_unmute: {
+        eve_handle
+            .mute(AudioBridgeMuteParams {
+                room: room_id.clone(),
+                id: alice.id.clone(),
+                secret: None,
+            })
+            .await
+            .expect("Failed to mute participant; mute_and_unmute");
+
+        // Alice should receive the mute event of herself
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = alice_events
+            .recv()
+            .await
+            .expect("Alice failed to receive event")
+        else {
+            panic!("Alice received unexpected event")
+        };
+
+        assert_eq!(
+            participants
+                .iter()
+                .find(|p| p.id == alice.id)
+                .expect("Alice not found")
+                .muted,
+            true
+        );
+
+        // Bob should receive the mute event of Alice
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = bob_events
+            .recv()
+            .await
+            .expect("Bob failed to receive event")
+        else {
+            panic!("Bob received unexpected event")
+        };
+
+        assert_eq!(
+            participants
+                .iter()
+                .find(|p| p.id == alice.id)
+                .expect("Alice not found")
+                .muted,
+            true
+        );
+
+        // Eve should receive the mute event of Alice
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = eve_events
+            .recv()
+            .await
+            .expect("Eve failed to receive event")
+        else {
+            panic!("Eve received unexpected event")
+        };
+
+        assert_eq!(
+            participants
+                .iter()
+                .find(|p| p.id == alice.id)
+                .expect("Alice not found")
+                .muted,
+            true
+        );
     }
 }
 

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -11,6 +11,7 @@ use jarust::plugins::audio_bridge::params::AudioBridgeEditParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeEditParamsOptional;
 use jarust::plugins::audio_bridge::params::AudioBridgeExistsParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeJoinParams;
+use jarust::plugins::audio_bridge::params::AudioBridgeJoinParamsOptional;
 use jarust::plugins::audio_bridge::params::AudioBridgeKickParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeListParticipantsParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeMuteParams;
@@ -173,11 +174,15 @@ async fn participants_e2e() {
 
     // Alice joins the room
     let alice = {
+        let display = Some("Alice".to_string());
         alice_handle
             .join_room(
                 AudioBridgeJoinParams {
                     room: room_id.clone(),
-                    optional: Default::default(),
+                    optional: AudioBridgeJoinParamsOptional {
+                        display: display.clone(),
+                        ..Default::default()
+                    },
                 },
                 None,
                 default_timeout,
@@ -202,7 +207,7 @@ async fn participants_e2e() {
 
         AudioBridgeParticipant {
             id,
-            display: None,
+            display,
             setup: false,
             muted: false,
             suspended: None,
@@ -213,11 +218,15 @@ async fn participants_e2e() {
 
     // Bob joins the room
     let bob = {
+        let display = Some("Bob".to_string());
         bob_handle
             .join_room(
                 AudioBridgeJoinParams {
                     room: room_id.clone(),
-                    optional: Default::default(),
+                    optional: AudioBridgeJoinParamsOptional {
+                        display: display.clone(),
+                        ..Default::default()
+                    },
                 },
                 None,
                 default_timeout,
@@ -246,7 +255,7 @@ async fn participants_e2e() {
 
         AudioBridgeParticipant {
             id,
-            display: None,
+            display,
             setup: false,
             muted: false,
             suspended: None,
@@ -257,11 +266,15 @@ async fn participants_e2e() {
 
     // Eve joins the room
     let eve = {
+        let display = Some("Eve".to_string());
         eve_handle
             .join_room(
                 AudioBridgeJoinParams {
                     room: room_id.clone(),
-                    optional: Default::default(),
+                    optional: AudioBridgeJoinParamsOptional {
+                        display: display.clone(),
+                        ..Default::default()
+                    },
                 },
                 None,
                 default_timeout,
@@ -292,7 +305,7 @@ async fn participants_e2e() {
 
         AudioBridgeParticipant {
             id,
-            display: None,
+            display,
             setup: false,
             muted: false,
             suspended: None,
@@ -599,23 +612,6 @@ async fn participants_e2e() {
             panic!("Eve received unexpected event")
         };
         assert_eq!(kicked, alice.id);
-
-        // Alice should not be in the room anymore
-        let participants = eve_handle
-            .list_participants(
-                AudioBridgeListParticipantsParams {
-                    room: room_id.clone(),
-                },
-                default_timeout,
-            )
-            .await
-            .expect("Failed to list participants")
-            .participants;
-        assert_eq!(
-            participants.contains(&alice),
-            false,
-            "Alice should be kicked"
-        );
     }
 }
 

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -11,6 +11,7 @@ use jarust::plugins::audio_bridge::params::AudioBridgeEditParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeEditParamsOptional;
 use jarust::plugins::audio_bridge::params::AudioBridgeExistsParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeJoinParams;
+use jarust::plugins::audio_bridge::params::AudioBridgeListParticipantsParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeMuteParams;
 use jarust::plugins::JanusId;
 use std::time::Duration;
@@ -209,7 +210,7 @@ async fn participants_e2e() {
     };
 
     // Bob joins the room
-    let _bob = {
+    let bob = {
         bob_handle
             .join_room(
                 AudioBridgeJoinParams {
@@ -253,7 +254,7 @@ async fn participants_e2e() {
     };
 
     // Eve joins the room
-    let _eve = {
+    let eve = {
         eve_handle
             .join_room(
                 AudioBridgeJoinParams {
@@ -285,6 +286,7 @@ async fn participants_e2e() {
             true,
             "Alice should be in room"
         );
+        assert_eq!(participants.contains(&bob), true, "Bob should be in room");
 
         AudioBridgeParticipant {
             id,
@@ -443,6 +445,28 @@ async fn participants_e2e() {
                 .muted,
             false
         );
+    }
+
+    'list_participants: {
+        let participants = eve_handle
+            .list_participants(
+                AudioBridgeListParticipantsParams {
+                    room: room_id.clone(),
+                },
+                default_timeout,
+            )
+            .await
+            .expect("Failed to list participants")
+            .participants;
+
+        assert_eq!(participants.len(), 3);
+        assert_eq!(
+            participants.contains(&alice),
+            true,
+            "Alice should be in room"
+        );
+        assert_eq!(participants.contains(&bob), true, "Bob should be in room");
+        assert_eq!(participants.contains(&eve), true, "Eve should be in room");
     }
 }
 

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -297,7 +297,7 @@ async fn participants_e2e() {
         }
     };
 
-    'mute_and_unmute: {
+    'mute: {
         eve_handle
             .mute(AudioBridgeMuteParams {
                 room: room_id.clone(),
@@ -368,6 +368,80 @@ async fn participants_e2e() {
                 .expect("Alice not found")
                 .muted,
             true
+        );
+    }
+
+    'unmute: {
+        eve_handle
+            .unmute(AudioBridgeMuteParams {
+                room: room_id.clone(),
+                id: alice.id.clone(),
+                secret: None,
+            })
+            .await
+            .expect("Failed to unmute participant; mute_and_unmute");
+
+        // Alice should receive the unmute event of herself
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = alice_events
+            .recv()
+            .await
+            .expect("Alice failed to receive event")
+        else {
+            panic!("Alice received unexpected event")
+        };
+
+        assert_eq!(
+            participants
+                .iter()
+                .find(|p| p.id == alice.id)
+                .expect("Alice not found")
+                .muted,
+            false
+        );
+
+        // Bob should receive the unmute event of Alice
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = bob_events
+            .recv()
+            .await
+            .expect("Bob failed to receive event")
+        else {
+            panic!("Bob received unexpected event")
+        };
+
+        assert_eq!(
+            participants
+                .iter()
+                .find(|p| p.id == alice.id)
+                .expect("Alice not found")
+                .muted,
+            false
+        );
+
+        // Eve should receive the unmute event of Alice
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = eve_events
+            .recv()
+            .await
+            .expect("Eve failed to receive event")
+        else {
+            panic!("Eve received unexpected event")
+        };
+
+        assert_eq!(
+            participants
+                .iter()
+                .find(|p| p.id == alice.id)
+                .expect("Alice not found")
+                .muted,
+            false
         );
     }
 }

--- a/jarust_plugins/src/video_room/responses.rs
+++ b/jarust_plugins/src/video_room/responses.rs
@@ -198,16 +198,6 @@ pub struct AttachedStream {
     /// whether this stream is ready to start sending media (will be false at the beginning)
     pub ready: bool,
 
-    /// optional object containing simulcast info, if simulcast is used by this stream
-    // pub simulcast: Option<?>, TODO: figure out undocumented object
-
-    /// optional object containing SVC info, if SVC is used by this stream
-    // pub svc: Option<?>, TODO: figure out undocumented object
-
-    /// optional object containing info on the playout-delay extension configuration, if in use
-    // #[serde(rename = "playout-delay")]
-    // pub playout_delay: Option<?>, TODO: figure out undocumented object
-
     /// if this is a data channel stream, the number of data channel subscriptions
     pub sources: Option<i64>,
 


### PR DESCRIPTION
Started as a testing branch but added support for events captured by e2es

- Fix Rust 1.83 clippy warnings
- Added support for participant kicked and room muted events
- Added participants e2e tests. Join room, mute and unmute participant, mute and unmute room, list participants, and kick participant

Todo (another PR, I want to upgrade the janus docker image first):
- Leave tests
- Kick all tests
- Change room tests
- Configure
