### PR TITLE
feat/v1.0 finalizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,5 +14,6 @@ test-plugins = [
     "-p",
     "jarust_plugins",
     "--features",
-    "use-native-tls,echo-test,audio-bridge,video-room,streaming,__experimental",
+    "use-native-tls,__all-features",
 ]
+clippy-all = ["clippy", "--features", "__all-features"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,18 @@
+[alias]
+test-core = ["test", "-p", "jarust_core", "--features", "use-native-tls"]
+test-e2e = ["test", "-p", "e2e"]
+test-interface = [
+    "test",
+    "-p",
+    "jarust_interface",
+    "--features",
+    "use-native-tls",
+]
+test-jarust = ["test", "-p", "jarust", "--features", "use-native-tls"]
+test-plugins = [
+    "test",
+    "-p",
+    "jarust_plugins",
+    "--features",
+    "use-native-tls,echo-test,audio-bridge,video-room,streaming,__experimental",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --workspace --exclude e2e
+      - run: cargo test-core
+      - run: cargo test-interface
+      - run: cargo test-jarust
+      - run: cargo test-plugins
 
   e2e:
     name: E2E tests
@@ -32,4 +35,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hoverkraft-tech/compose-action@v2.0.1
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test -p e2e
+      - run: cargo test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo clippy
+      - run: cargo clippy-all
 
   test:
     name: Integration test
@@ -21,10 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test-core
-      - run: cargo test-interface
-      - run: cargo test-jarust
-      - run: cargo test-plugins
+      - run: |
+          cargo test-core
+          cargo test-interface
+          cargo test-jarust
+          cargo test-plugins
 
   e2e:
     name: E2E tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,14 @@ Manual testing is done by spinning up a docker image with janus server and point
 - Serialization testing, it might look tedious to test (de)serialization, but the responses and events coming from janus will have different structure and fields, thanks to `serde` we could model them within the type system. But `serde` has it's complexities when we start using `flatten` with `untagged` and `tag = ""`, so serialization testing became essential to ensure a specific event will be (de)serialized to it's type counter part.
 
 - End-to-End, the E2Es assume janus is running on the system and using the `e2e/server_config` configs, so keep that in mind when running them.
+
+## Plugins
+
+### Create a Plugin
+
+We're aiming to support the built-in plugins like SIP, Text room, and more. So, in order to create a new plugin you can follow the [`echotest`](./jarust_plugins/src/echo_test), it's simple and provides a simple architecture for plugins.
+
+### Experimental
+
+A feature might be merged before being completed and tested, such features should be marked as `__experimental`.
+To remove the `__experimental` flag, the feature should be manually tested and has an e2e test case.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ repository = "https://github.com/Ghamza-Jd/jarust"
 
 [workspace.dependencies]
 # Workspace crates
-jarust_core = { version = "0.8.1", path = "jarust_core", default-features = false }
-jarust_interface = { version = "0.8.1", path = "jarust_interface", default-features = false }
-jarust_plugins = { version = "0.8.1", path = "jarust_plugins", default-features = false }
-jarust_rt = { version = "0.8.1", path = "jarust_rt", default-features = false }
+jarust_core = { version = "0.8.1", path = "jarust_core" }
+jarust_interface = { version = "0.8.1", path = "jarust_interface" }
+jarust_plugins = { version = "0.8.1", path = "jarust_plugins" }
+jarust_rt = { version = "0.8.1", path = "jarust_rt" }
 
 # 3rd Party
 async-trait = "0.1.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,16 @@ jarust_plugins = { version = "0.8.1", path = "jarust_plugins", default-features 
 jarust_rt = { version = "0.8.1", path = "jarust_rt", default-features = false }
 
 # 3rd Party
-async-trait = "0.1.83"
-bytes = "1.8.0"
+async-trait = "0.1.85"
+bytes = "1.9.0"
 futures-util = "0.3.31"
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
-thiserror = "1.0.68"
-tokio = "1.41.1"
+rand = "0.8.5"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.135"
+thiserror = "1.0.69"
+tokio = "1.42.0"
 tracing = "0.1.41"
+
+# Dev deps
+anyhow = "1.0.95"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -9,17 +9,29 @@ to be customizable, for exmaple, you could use the built-in WebSocket transport 
 
 The library wraps the Janus core API and some of the most popular plugins APIs.
 
+## Plugins
+
 The supported Janus plugins currently are:
 
-- EchoTest
-- AudioBridge
-- Streaming
-- VideoRoom
+- [x] EchoTest
+- [x] AudioBridge
+- [x] Streaming ([Experimental](./CONTRIBUTING.md#experimental))
+- [x] VideoRoom ([Experimental](./CONTRIBUTING.md#experimental))
+
+## Interfaces
 
 The supported interfaces are:
 
-- WebSocket
-- Restful
+- [x] WebSocket
+- [x] Restful
+- [ ] MQTT
+- [ ] RabbitMQ
+- [ ] Nanomsg
+
+## APIs
+
+- [x] Client API
+- [ ] Admin/Monitor API
 
 ## Examples
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -15,10 +15,10 @@ publish = false
 doctest = false
 
 [dependencies]
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
+rand.workspace = true
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
 tracing.workspace = true
 

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -314,6 +314,23 @@ async fn participants_e2e() {
         }
     };
 
+    // Already joined participants should receive "joined" events but with different body, maybe `ParticipantJoined`
+    'participant_joined: {
+        alice_events
+            .recv()
+            .await
+            .expect("Alice failed to receive event");
+        alice_events
+            .recv()
+            .await
+            .expect("Alice failed to receive event");
+
+        bob_events
+            .recv()
+            .await
+            .expect("Bob failed to receive event");
+    }
+
     'mute: {
         eve_handle
             .mute(AudioBridgeMuteParams {

--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -314,21 +314,41 @@ async fn participants_e2e() {
         }
     };
 
-    // Already joined participants should receive "joined" events but with different body, maybe `ParticipantJoined`
-    'participant_joined: {
-        alice_events
+    'participants_joined: {
+        let bob_joined = alice_events
             .recv()
             .await
             .expect("Alice failed to receive event");
-        alice_events
+        let eve_joined = alice_events
             .recv()
             .await
             .expect("Alice failed to receive event");
+        assert_eq!(
+            bob_joined,
+            PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsJoined {
+                room: room_id.clone(),
+                participants: vec![bob.clone()]
+            })
+        );
+        assert_eq!(
+            eve_joined,
+            PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsJoined {
+                room: room_id.clone(),
+                participants: vec![eve.clone()]
+            })
+        );
 
-        bob_events
+        let eve_joined = bob_events
             .recv()
             .await
             .expect("Bob failed to receive event");
+        assert_eq!(
+            eve_joined,
+            PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsJoined {
+                room: room_id.clone(),
+                participants: vec![eve.clone()]
+            })
+        );
     }
 
     'mute: {

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -52,9 +52,13 @@ anyhow.workspace = true
 async-trait.workspace = true
 jarust_core = { workspace = true, default-features = true }
 jarust_interface = { workspace = true, default-features = true }
-jarust_plugins = { workspace = true, default-features = true }
 serde_json.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber.workspace = true
 tracing.workspace = true
+
+[dev-dependencies.jarust_plugins]
+workspace = true
+default_features = true
+features = ["__experimental"]

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -48,7 +48,7 @@ tokio-rt = [
 ]
 
 [dev-dependencies]
-anyhow = "1.0.93"
+anyhow.workspace = true
 async-trait.workspace = true
 jarust_core = { workspace = true, default-features = true }
 jarust_interface = { workspace = true, default-features = true }
@@ -56,5 +56,5 @@ jarust_plugins = { workspace = true, default-features = true }
 serde_json.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/jarust/Cargo.toml
+++ b/jarust/Cargo.toml
@@ -50,8 +50,6 @@ tokio-rt = [
 [dev-dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-jarust_core = { workspace = true, default-features = true }
-jarust_interface = { workspace = true, default-features = true }
 serde_json.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -60,5 +58,10 @@ tracing.workspace = true
 
 [dev-dependencies.jarust_plugins]
 workspace = true
-default_features = true
-features = ["__experimental"]
+features = [
+    "__experimental",
+    "audio-bridge",
+    "echo-test",
+    "streaming",
+    "video-room",
+]

--- a/jarust/examples/echotest.rs
+++ b/jarust/examples/echotest.rs
@@ -57,6 +57,9 @@ async fn main() -> anyhow::Result<()> {
             PluginEvent::EchoTestEvent(EchoTestEvent::Error { error_code, error }) => {
                 tracing::warn!("error: {{ error_code: {error_code}, error: {error} }}");
             }
+            PluginEvent::EchoTestEvent(EchoTestEvent::Other(value)) => {
+                tracing::debug!("other: {value:#?}");
+            }
             PluginEvent::GenericEvent(event) => {
                 tracing::debug!("generic event: {event:#?}");
             }

--- a/jarust/examples/echotest_start_with_est.rs
+++ b/jarust/examples/echotest_start_with_est.rs
@@ -65,6 +65,9 @@ async fn main() -> anyhow::Result<()> {
             PluginEvent::EchoTestEvent(EchoTestEvent::Error { error_code, error }) => {
                 tracing::warn!("error: {{ error_code: {error_code}, error: {error} }}");
             }
+            PluginEvent::EchoTestEvent(EchoTestEvent::Other(value)) => {
+                tracing::debug!("other: {value:#?}");
+            }
             PluginEvent::GenericEvent(event) => {
                 tracing::debug!("generic event: {event:#?}");
             }

--- a/jarust/examples/secure_ws.rs
+++ b/jarust/examples/secure_ws.rs
@@ -15,7 +15,8 @@ use tracing_subscriber::EnvFilter;
 async fn main() -> anyhow::Result<()> {
     let filename = Path::new(file!()).file_stem().unwrap().to_str().unwrap();
     let env_filter = EnvFilter::from_default_env()
-        .add_directive("jarust_core=debug".parse()?)
+        .add_directive("jarust_core=trace".parse()?)
+        .add_directive("jarust_interface=trace".parse()?)
         .add_directive(format!("{filename}=info").parse()?);
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
 

--- a/jarust_core/Cargo.toml
+++ b/jarust_core/Cargo.toml
@@ -29,8 +29,8 @@ use-native-tls = ["jarust_interface/use-native-tls"]
 use-rustls = ["jarust_interface/use-rustls"]
 
 [dev-dependencies]
-anyhow = "1.0.93"
+anyhow.workspace = true
 jarust_interface = { workspace = true, default-features = true }
 jarust_rt = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber.workspace = true

--- a/jarust_core/Cargo.toml
+++ b/jarust_core/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 
 [features]
-default = ["tokio-rt", "use-native-tls"]
 tokio-rt = ["jarust_rt/tokio-rt", "jarust_interface/tokio-rt"]
 use-native-tls = ["jarust_interface/use-native-tls"]
 use-rustls = ["jarust_interface/use-rustls"]

--- a/jarust_interface/Cargo.toml
+++ b/jarust_interface/Cargo.toml
@@ -29,15 +29,14 @@ tracing.workspace = true
 uuid = { version = "1.11.0", features = ["fast-rng", "v4"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-rustls = { version = "0.23.13", optional = true }
-rustls-native-certs = { version = "0.8.0", optional = true }
+rustls = { version = "0.23.20", optional = true }
+rustls-native-certs = { version = "0.8.1", optional = true }
 tokio-tungstenite = "0.26.1"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
 
 [features]
-default = ["use-native-tls", "tokio-rt"]
 use-native-tls = ["tokio-tungstenite/native-tls"]
 use-rustls = ["rustls", "rustls-native-certs", "tokio-tungstenite/__rustls-tls"]
 tokio-rt = ["jarust_rt/tokio-rt"]

--- a/jarust_interface/Cargo.toml
+++ b/jarust_interface/Cargo.toml
@@ -17,10 +17,10 @@ doctest = false
 async-trait.workspace = true
 bytes.workspace = true
 futures-util.workspace = true
-indexmap = "2.6.0"
+indexmap = "2.7.0"
 jarust_rt.workspace = true
-rand = "0.8.5"
-reqwest = { version = "0.12.9", features = ["json"] }
+rand.workspace = true
+reqwest = { version = "0.12.12", features = ["json"] }
 serde_json.workspace = true
 serde.workspace = true
 thiserror.workspace = true
@@ -31,7 +31,7 @@ uuid = { version = "1.11.0", features = ["fast-rng", "v4"] }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rustls = { version = "0.23.13", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
-tokio-tungstenite = "0.24.0"
+tokio-tungstenite = "0.26.1"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/jarust_interface/src/websocket/connector/mod.rs
+++ b/jarust_interface/src/websocket/connector/mod.rs
@@ -1,0 +1,15 @@
+#[cfg(all(feature = "use-rustls", feature = "use-native-tls"))]
+compile_error!("Feature \"rustls\" and feature \"native-tls\" cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "use-rustls", feature = "use-native-tls")))]
+compile_error!("Either feature \"rustls\" or \"native-tls\" must be enabled for this crate");
+
+#[cfg(feature = "use-native-tls")]
+#[path = "native_tls_adapter.rs"]
+mod adapter;
+
+#[cfg(feature = "use-rustls")]
+#[path = "rustls_adapter.rs"]
+mod adapter;
+
+pub use adapter::connect_async;

--- a/jarust_interface/src/websocket/connector/native_tls_adapter.rs
+++ b/jarust_interface/src/websocket/connector/native_tls_adapter.rs
@@ -1,0 +1,14 @@
+use crate::Error;
+use tokio::net::TcpStream;
+use tokio_tungstenite::connect_async_with_config;
+use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::MaybeTlsStream;
+use tokio_tungstenite::WebSocketStream;
+
+pub async fn connect_async(
+    request: Request,
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Error> {
+    tracing::trace!("Using native-tls");
+    let (stream, ..) = connect_async_with_config(request, None, false).await?;
+    Ok(stream)
+}

--- a/jarust_interface/src/websocket/connector/rustls_adapter.rs
+++ b/jarust_interface/src/websocket/connector/rustls_adapter.rs
@@ -1,0 +1,28 @@
+use crate::Error;
+use rustls::RootCertStore;
+use std::sync::Arc;
+use tokio::net::TcpStream;
+use tokio_tungstenite::connect_async_tls_with_config;
+use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::Connector;
+use tokio_tungstenite::MaybeTlsStream;
+use tokio_tungstenite::WebSocketStream;
+
+fn make_tls_client_config() -> Result<Arc<rustls::ClientConfig>, Error> {
+    let mut root_store = RootCertStore::empty();
+    let platform_certs = rustls_native_certs::load_native_certs().certs;
+    root_store.add_parsable_certificates(platform_certs);
+    let client_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    Ok(Arc::new(client_config))
+}
+
+pub async fn connect_async(
+    request: Request,
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Error> {
+    tracing::trace!("Using rustls");
+    let connector = Connector::Rustls(make_tls_client_config()?);
+    let (stream, ..) = connect_async_tls_with_config(request, None, true, Some(connector)).await?;
+    Ok(stream)
+}

--- a/jarust_interface/src/websocket/mod.rs
+++ b/jarust_interface/src/websocket/mod.rs
@@ -1,3 +1,4 @@
+mod connector;
 mod demuxer;
 mod napmap;
 mod ringbuf_map;

--- a/jarust_interface/src/websocket/websocket_client.rs
+++ b/jarust_interface/src/websocket/websocket_client.rs
@@ -1,39 +1,20 @@
-#[cfg(all(feature = "use-rustls", feature = "use-native-tls"))]
-compile_error!("Feature \"rustls\" and feature \"native-tls\" cannot be enabled at the same time");
-
-#[cfg(not(any(feature = "use-rustls", feature = "use-native-tls")))]
-compile_error!("Either feature \"rustls\" or \"native-tls\" must be enabled for this crate");
-
+use crate::websocket::connector;
 use crate::Error;
 use bytes::Bytes;
 use futures_util::stream::SplitSink;
+use futures_util::stream::StreamExt;
 use futures_util::SinkExt;
-use futures_util::StreamExt;
 use jarust_rt::JaTask;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::handshake::client::Request;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::WebSocketStream;
 
-#[cfg(feature = "use-rustls")]
-use rustls::RootCertStore;
-#[cfg(feature = "use-rustls")]
-use std::sync::Arc;
-#[cfg(feature = "use-rustls")]
-use tokio_tungstenite::connect_async_tls_with_config;
-#[cfg(feature = "use-native-tls")]
-use tokio_tungstenite::connect_async_with_config;
-#[cfg(feature = "use-rustls")]
-use tokio_tungstenite::Connector;
-
-type WebSocketSender = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
-
 #[derive(Debug)]
 pub struct WebSocketClient {
-    sender: Option<WebSocketSender>,
+    sender: Option<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
     task: Option<JaTask>,
 }
 
@@ -57,7 +38,7 @@ impl WebSocketClient {
         let mut request = url.into_client_request()?;
         let headers = request.headers_mut();
         headers.insert("Sec-Websocket-Protocol", "janus-protocol".parse()?);
-        let stream = Self::connect_async(request).await?;
+        let stream = connector::connect_async(request).await?;
 
         let (sender, mut receiver) = stream.split();
         let (tx, rx) = mpsc::unbounded_channel();
@@ -84,37 +65,6 @@ impl WebSocketClient {
             return Err(Error::TransportNotOpened);
         }
         Ok(())
-    }
-}
-
-impl WebSocketClient {
-    #[cfg(feature = "use-rustls")]
-    fn make_tls_client_config() -> Result<Arc<rustls::ClientConfig>, Error> {
-        let mut root_store = RootCertStore::empty();
-        let platform_certs = rustls_native_certs::load_native_certs().certs;
-        root_store.add_parsable_certificates(platform_certs);
-        let client_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        Ok(Arc::new(client_config))
-    }
-
-    async fn connect_async(
-        request: Request,
-    ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Error> {
-        #[cfg(feature = "use-rustls")]
-        {
-            let connector = Connector::Rustls(WebSocketClient::make_tls_client_config()?);
-            let (stream, ..) =
-                connect_async_tls_with_config(request, None, true, Some(connector)).await?;
-            Ok(stream)
-        }
-
-        #[cfg(feature = "use-native-tls")]
-        {
-            let (stream, ..) = connect_async_with_config(request, None, false).await?;
-            Ok(stream)
-        }
     }
 }
 

--- a/jarust_interface/src/websocket/websocket_client.rs
+++ b/jarust_interface/src/websocket/websocket_client.rs
@@ -76,7 +76,7 @@ impl WebSocketClient {
     }
 
     pub async fn send(&mut self, data: &[u8], _: &str) -> Result<(), Error> {
-        let item = Message::Binary(data.to_vec());
+        let item = Message::Binary(data.to_vec().into());
         if let Some(sender) = &mut self.sender {
             sender.send(item).await?;
         } else {

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -49,9 +49,9 @@ use-native-tls = ["jarust_interface/use-native-tls"]
 use-rustls = ["jarust_interface/use-rustls"]
 
 [dev-dependencies]
-anyhow = "1.0.93"
+anyhow.workspace = true
 jarust_core = { workspace = true, default-features = true }
 jarust_interface = { workspace = true, default-features = true }
 jarust_rt = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber.workspace = true

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -31,6 +31,15 @@ video-room = []
 streaming = []
 __experimental = []
 
+# For internal use
+__all-features = [
+    "echo-test",
+    "audio-bridge",
+    "video-room",
+    "streaming",
+    "__experimental",
+]
+
 tokio-rt = [
     "jarust_rt/tokio-rt",
     "jarust_interface/tokio-rt",

--- a/jarust_plugins/Cargo.toml
+++ b/jarust_plugins/Cargo.toml
@@ -25,14 +25,6 @@ tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 
 [features]
-default = [
-    "tokio-rt",
-    "use-native-tls",
-    "echo-test",
-    "audio-bridge",
-    "video-room",
-    "streaming",
-]
 echo-test = []
 audio-bridge = []
 video-room = []

--- a/jarust_plugins/README.md
+++ b/jarust_plugins/README.md
@@ -4,7 +4,7 @@ Wrapper around [jarust_core](https://crates.io/crates/jarust_core) that provides
 
 Current plugins:
 
-- [x] Echo test
-- [x] Audio bridge
-- [x] Video room
-- [ ] Streaming (WiP)
+- [x] EchoTest
+- [x] AudioBridge
+- [x] Streaming (Experimental)
+- [x] VideoRoom (Experimental)

--- a/jarust_plugins/src/audio_bridge/events.rs
+++ b/jarust_plugins/src/audio_bridge/events.rs
@@ -459,4 +459,33 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn it_parse_unsupported_event_as_other() {
+        let rsp = JaResponse {
+            janus: ResponseType::Event(JaHandleEvent::PluginEvent {
+                plugin_data: PluginData {
+                    plugin: "janus.plugin.audiobridge".to_string(),
+                    data: PluginInnerData::Data(json!({
+                        "audiobridge": "jarust_rocks",
+                        "room": 6613848040355181645u64,
+                        "jarust": "rocks"
+                    })),
+                },
+            }),
+            jsep: None,
+            transaction: None,
+            session_id: None,
+            sender: None,
+        };
+        let event: PluginEvent = rsp.try_into().unwrap();
+        assert_eq!(
+            event,
+            PluginEvent::AudioBridgeEvent(AudioBridgeEvent::Other(json!({
+                "audiobridge": "jarust_rocks",
+                "room": 6613848040355181645u64,
+                "jarust": "rocks"
+            })))
+        );
+    }
 }

--- a/jarust_plugins/src/audio_bridge/handle.rs
+++ b/jarust_plugins/src/audio_bridge/handle.rs
@@ -1,12 +1,5 @@
 use super::params::*;
-use super::responses::AudioBridgeAllowedRsp;
-use super::responses::AudioBridgeExistsRoomRsp;
-use super::responses::AudioBridgeListParticipantsRsp;
-use super::responses::AudioBridgeListRoomsRsp;
-use super::responses::AudioBridgeRoom;
-use super::responses::AudioBridgeRoomCreatedRsp;
-use super::responses::AudioBridgeRoomDestroyedRsp;
-use super::responses::AudioBridgeRoomEditedRsp;
+use super::responses::*;
 use crate::JanusId;
 use jarust_core::prelude::*;
 use jarust_interface::japrotocol::Jsep;
@@ -92,11 +85,12 @@ impl AudioBridgeHandle {
             .await
     }
 
+    #[cfg(feature = "__experimental")]
     /// To enable or disable recording of mixed audio stream while the conference is in progress
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn enable_recording(
         &self,
-        params: AudioBridgeDestroyParams,
+        params: AudioBridgeEnableRecordingParams,
         timeout: Duration,
     ) -> Result<(), jarust_interface::Error> {
         tracing::info!(plugin = "audiobridge", "Sending enable recording");
@@ -111,9 +105,10 @@ impl AudioBridgeHandle {
     /// While a recording for each participant can be enabled or disabled separately, there also is a request
     /// to enable or disable them in bulk, thus implementing a feature similar to enable_recording but for MJR
     /// files, rather than for a .wav mix
+    #[cfg(feature = "__experimental")]
     pub async fn enable_mjrs(
         &self,
-        params: AudioBridgeDestroyParams,
+        params: AudioBridgeEnableMjrsParams,
         timeout: Duration,
     ) -> Result<(), jarust_interface::Error> {
         tracing::info!(plugin = "audiobridge", "Sending enable mjrs");
@@ -141,6 +136,7 @@ impl AudioBridgeHandle {
     }
 
     /// Allows you to edit who's allowed to join a room via ad-hoc tokens
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn allowed(
         &self,
@@ -198,6 +194,7 @@ impl AudioBridgeHandle {
     }
 
     /// Kicks all participants out of a room
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn kick_all(
         &self,
@@ -235,6 +232,7 @@ impl AudioBridgeHandle {
     }
 
     /// Configure the media related settings of the participant
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn configure(
         &self,
@@ -294,6 +292,7 @@ impl AudioBridgeHandle {
     }
 
     /// Change the room you are in, instead of leaving and joining a new room
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn change_room(
         &self,
@@ -308,6 +307,7 @@ impl AudioBridgeHandle {
     }
 
     /// Leave an audio room
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn leave(&self, timeout: Duration) -> Result<(), jarust_interface::Error> {
         tracing::info!(plugin = "audiobridge", "Sending leave");

--- a/jarust_plugins/src/audio_bridge/params.rs
+++ b/jarust_plugins/src/audio_bridge/params.rs
@@ -86,6 +86,7 @@ make_dto!(
     }
 );
 
+#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeEnableRecordingParams,
     required { room: JanusId },
@@ -101,6 +102,7 @@ make_dto!(
     }
 );
 
+#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeEnableMjrsParams,
     required { room: JanusId },
@@ -116,6 +118,7 @@ make_dto!(
 
 make_dto!(AudioBridgeExistsParams, required { room: JanusId });
 
+#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeAllowedParams,
     required {
@@ -130,6 +133,7 @@ make_dto!(
     }
 );
 
+#[cfg(feature = "__experimental")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AudioBridgeAllowAction {
@@ -152,6 +156,7 @@ make_dto!(
     }
 );
 
+#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeKickAllParams,
     required { room: JanusId },
@@ -262,6 +267,7 @@ pub enum AudioBridgeCodec {
     Pcmu,
 }
 
+#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeConfigureParams,
     optional {
@@ -314,6 +320,7 @@ make_dto!(
     }
 );
 
+#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeChangeRoomParams,
     required { room: JanusId },

--- a/jarust_plugins/src/audio_bridge/responses.rs
+++ b/jarust_plugins/src/audio_bridge/responses.rs
@@ -37,6 +37,7 @@ pub struct AudioBridgeRoom {
     pub muted: bool,
 }
 
+#[cfg(feature = "__experimental")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize)]
 pub struct AudioBridgeAllowedRsp {
     pub room: JanusId,

--- a/jarust_plugins/src/echo_test/events.rs
+++ b/jarust_plugins/src/echo_test/events.rs
@@ -178,4 +178,31 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn it_parse_unsupported_event_as_other() {
+        let rsp = JaResponse {
+            janus: ResponseType::Event(JaHandleEvent::PluginEvent {
+                plugin_data: PluginData {
+                    plugin: "janus.plugin.echotest".to_string(),
+                    data: PluginInnerData::Data(json!({
+                        "echotest": "jarust_rocks",
+                        "jarust": "rocks"
+                    })),
+                },
+            }),
+            jsep: None,
+            transaction: None,
+            session_id: None,
+            sender: None,
+        };
+        let event: PluginEvent = rsp.try_into().unwrap();
+        assert_eq!(
+            event,
+            PluginEvent::EchoTestEvent(EchoTestEvent::Other(json!({
+                "echotest": "jarust_rocks",
+                "jarust": "rocks"
+            })))
+        );
+    }
 }

--- a/jarust_plugins/src/streaming/events.rs
+++ b/jarust_plugins/src/streaming/events.rs
@@ -175,4 +175,31 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn it_parse_unsupported_event_as_other() {
+        let rsp = JaResponse {
+            janus: ResponseType::Event(JaHandleEvent::PluginEvent {
+                plugin_data: PluginData {
+                    plugin: "janus.plugin.streaming".to_string(),
+                    data: PluginInnerData::Data(json!({
+                        "streaming": "jarust_rocks",
+                        "jarust": "rocks"
+                    })),
+                },
+            }),
+            jsep: None,
+            transaction: None,
+            session_id: None,
+            sender: None,
+        };
+        let event: PluginEvent = rsp.try_into().unwrap();
+        assert_eq!(
+            event,
+            PluginEvent::StreamingEvent(StreamingEvent::Other(json!({
+                "streaming": "jarust_rocks",
+                "jarust": "rocks"
+            })))
+        );
+    }
 }

--- a/jarust_plugins/src/streaming/handle.rs
+++ b/jarust_plugins/src/streaming/handle.rs
@@ -17,6 +17,7 @@ pub struct StreamingHandle {
 // synchronous methods
 //
 impl StreamingHandle {
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn create_mountpoint(
         &self,
@@ -32,6 +33,7 @@ impl StreamingHandle {
             .await
     }
 
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn destroy_mountpoint(
         &self,
@@ -47,6 +49,7 @@ impl StreamingHandle {
             .await
     }
 
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn list(
         &self,
@@ -61,6 +64,7 @@ impl StreamingHandle {
         Ok(response.list)
     }
 
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn info(
         &self,

--- a/jarust_plugins/src/video_room/events.rs
+++ b/jarust_plugins/src/video_room/events.rs
@@ -703,4 +703,33 @@ mod tests {
             })
         )
     }
+
+    #[test]
+    fn it_parse_unsupported_event_as_other() {
+        let rsp = JaResponse {
+            janus: ResponseType::Event(JaHandleEvent::PluginEvent {
+                plugin_data: PluginData {
+                    plugin: "janus.plugin.videoroom".to_string(),
+                    data: PluginInnerData::Data(json!({
+                        "videoroom": "jarust_rocks",
+                        "room": 6613848040355181645u64,
+                        "jarust": "rocks"
+                    })),
+                },
+            }),
+            jsep: None,
+            transaction: None,
+            session_id: None,
+            sender: None,
+        };
+        let event: PluginEvent = rsp.try_into().unwrap();
+        assert_eq!(
+            event,
+            PluginEvent::VideoRoomEvent(VideoRoomEvent::Other(json!({
+                "videoroom": "jarust_rocks",
+                "room": 6613848040355181645u64,
+                "jarust": "rocks"
+            })))
+        );
+    }
 }

--- a/jarust_plugins/src/video_room/handle.rs
+++ b/jarust_plugins/src/video_room/handle.rs
@@ -23,6 +23,7 @@ impl VideoRoomHandle {
     ///
     /// ### Note:
     /// Random room number will be used if `room` is `None`
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn create_room(
         &self,
@@ -44,6 +45,7 @@ impl VideoRoomHandle {
     ///
     /// ### Note:
     /// Random room number will be used if `room` is `None`
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn create_room_with_config(
         &self,
@@ -64,6 +66,7 @@ impl VideoRoomHandle {
     /// ### Note:
     /// You won't be able to modify other more static properties,
     /// like the room ID, the sampling rate, the extensions-related stuff and so on.
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn edit_room(
         &self,
@@ -80,6 +83,7 @@ impl VideoRoomHandle {
     }
 
     // Destroy an existing video room, whether created dynamically or statically
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn destroy_room(
         &self,
@@ -96,6 +100,7 @@ impl VideoRoomHandle {
     }
 
     /// Check whether a room exists
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn exists(
         &self,
@@ -111,6 +116,7 @@ impl VideoRoomHandle {
     }
 
     /// Get a list of the available rooms
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn list_rooms(
         &self,
@@ -126,6 +132,7 @@ impl VideoRoomHandle {
     }
 
     /// Allows you to edit who's allowed to join a room via ad-hoc tokens
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn allowed(
         &self,
@@ -152,6 +159,7 @@ impl VideoRoomHandle {
     }
 
     /// Kicks a participants out of a room
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn kick(
         &self,
@@ -166,6 +174,7 @@ impl VideoRoomHandle {
     }
 
     /// Enable or disable recording on all participants while the conference is in progress
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn enable_recording(
         &self,
@@ -180,6 +189,7 @@ impl VideoRoomHandle {
     }
 
     /// Get a list of the participants in a specific room
+    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn list_participants(
         &self,
@@ -194,6 +204,7 @@ impl VideoRoomHandle {
             .await
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn moderate(
         &self,
         params: VideoRoomModerateParams,
@@ -205,6 +216,7 @@ impl VideoRoomHandle {
         self.handle.send_waiton_rsp::<()>(message, timeout).await
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn list_forwarders(
         &self,
         params: VideoRoomListForwardersParams,
@@ -218,6 +230,7 @@ impl VideoRoomHandle {
             .await
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn rtp_forward(
         &self,
         params: VideoRoomRtpForwardParams,
@@ -231,6 +244,7 @@ impl VideoRoomHandle {
             .await
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn stop_rtp_forward(
         &self,
         params: VideoRoomStopRtpForward,
@@ -258,6 +272,7 @@ impl VideoRoomHandle {
     /// A successful join will result in a [`VideoRoomEvent::RoomJoined`](super::events::VideoRoomEvent::RoomJoined) event,
     /// which will contain a list of the currently active (as in publishing via WebRTC) publishers,
     /// and optionally a list of passive attendees (but only if the room was configured with notify_joining set to TRUE)
+    #[cfg(feature = "__experimental")]
     pub async fn join_as_publisher(
         &self,
         params: VideoRoomPublisherJoinParams,
@@ -291,6 +306,7 @@ impl VideoRoomHandle {
     /// can be removed/updated accordingly as well. As such, these subscriber sessions are dependent on feedback
     /// obtained by publishers, and can't exist on their own, unless you feed them the right info out of band
     /// (which is impossible in rooms configured with require_pvtid).
+    #[cfg(feature = "__experimental")]
     pub async fn join_as_subscriber(
         &self,
         params: VideoRoomSubscriberJoinParams,
@@ -317,6 +333,7 @@ impl VideoRoomHandle {
     /// It's basically the same properties as those listed for publish , with the addition of a `streams` array that can be used
     /// to tweak individual streams (which is not available when publishing since in that case the stream doesn't exist yet).
     /// Notice that the configure request can also be used in renegotiations, to provide an updated SDP with changes to the published media.
+    #[cfg(feature = "__experimental")]
     pub async fn configure_publisher(
         &self,
         params: VideoRoomConfigurePublisherParams,
@@ -330,6 +347,7 @@ impl VideoRoomHandle {
 
     /// This request allows subscribers to dynamically change some properties associated to their media subscription,
     /// e.g., in terms of what should and should not be sent at a specific time.
+    #[cfg(feature = "__experimental")]
     pub async fn configure_subscriber(
         &self,
         params: VideoRoomConfigureSubscriberParams,
@@ -342,6 +360,7 @@ impl VideoRoomHandle {
     }
 
     /// A combination of [VideoRoomHandle::join_as_publisher()] and [VideoRoomHandle::configure_publisher()]
+    #[cfg(feature = "__experimental")]
     pub async fn join_and_configure(
         &self,
         join_and_configure_params: VideoRoomJoinAndConfigureParams,
@@ -359,6 +378,7 @@ impl VideoRoomHandle {
     /// The plugin will match it to the room configuration (e.g., to make sure the codecs you negotiated are allowed in the room),
     /// and will reply with a JSEP SDP answer to close the circle and complete the setup of the PeerConnection.
     /// As soon as the PeerConnection has been established, the publisher will become active, and a new active feed other participants can subscribe to.
+    #[cfg(feature = "__experimental")]
     pub async fn publish(
         &self,
         params: VideoRoomPublishParams,
@@ -376,6 +396,7 @@ impl VideoRoomHandle {
     /// Stop publishing and tear down the related PeerConnection
     ///
     /// This request requires no arguments as the context is implicit.
+    #[cfg(feature = "__experimental")]
     pub async fn unpublish(&self, timeout: Duration) -> Result<(), jarust_interface::Error> {
         self.handle
             .send_waiton_ack(json!({"request": "unpublish"}), timeout)
@@ -387,6 +408,7 @@ impl VideoRoomHandle {
     ///
     /// The subscriber is supposed to send a JSEP SDP answer back to the plugin by the means of this request,
     /// which in this case MUST be associated with a JSEP SDP answer but otherwise requires no arguments.
+    #[cfg(feature = "__experimental")]
     pub async fn start(
         &self,
         jsep: Jsep,
@@ -398,6 +420,7 @@ impl VideoRoomHandle {
         Ok(())
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn subscribe(
         &self,
         params: VideoRoomSubscribeParams,
@@ -409,6 +432,7 @@ impl VideoRoomHandle {
         Ok(())
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn unsubscribe(
         &self,
         params: VideoRoomUnsubscribeParams,
@@ -420,6 +444,7 @@ impl VideoRoomHandle {
         Ok(())
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn update(
         &self,
         params: VideoRoomCombinedUpdateParams,
@@ -431,6 +456,7 @@ impl VideoRoomHandle {
         Ok(())
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn pause(&self, timeout: Duration) -> Result<(), jarust_interface::Error> {
         self.handle
             .send_waiton_ack(json!({"request": "pause"}), timeout)
@@ -438,6 +464,7 @@ impl VideoRoomHandle {
         Ok(())
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn switch(
         &self,
         params: VideoRoomSwitchParams,
@@ -449,6 +476,7 @@ impl VideoRoomHandle {
         Ok(())
     }
 
+    #[cfg(feature = "__experimental")]
     pub async fn leave(&self, timeout: Duration) -> Result<(), jarust_interface::Error> {
         self.handle
             .send_waiton_ack(json!({"request": "leave"}), timeout)


### PR DESCRIPTION
1.0 Release!

- Going to release 1.0 without stabilising all of the plugins, on the other hand, the functionality that's isn't tested manually and have e2e test case will be hidden behind `__experimental` feature until the tests are done.

- Plugin events now exposed `Other` variant, so anything isn't yet captured by the library can be parsed and handle on the user side

- Minor tls refactoring

- `Other` variant tests

- Adding audio bridge events, found while adding `Other`

- Docs update regarding the crate in general, the usage, feature flags, and contributing