### PR TITLE
Feat: stabalize "configure" request

### DIFF
--- a/e2e/tests/audiobridge.rs
+++ b/e2e/tests/audiobridge.rs
@@ -7,6 +7,7 @@ use jarust::plugins::audio_bridge::events::PluginEvent;
 use jarust::plugins::audio_bridge::handle::AudioBridgeHandle;
 use jarust::plugins::audio_bridge::jahandle_ext::AudioBridge;
 use jarust::plugins::audio_bridge::params::AudioBridgeChangeRoomParams;
+use jarust::plugins::audio_bridge::params::AudioBridgeConfigureParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeDestroyParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeEditParams;
 use jarust::plugins::audio_bridge::params::AudioBridgeEditParamsOptional;
@@ -499,6 +500,71 @@ async fn participants_e2e() {
                 .muted,
             false
         );
+    }
+
+    'configure: {
+        let new_display = "configure request test".to_string();
+        eve_handle
+            .configure(
+                AudioBridgeConfigureParams {
+                    muted: Some(true),
+                    display: Some(new_display.clone()),
+                    ..Default::default()
+                },
+                None,
+                default_timeout,
+            )
+            .await
+            .expect("Eve failed to configure");
+
+        // Alice should receive the mute event of eve
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = alice_events
+            .recv()
+            .await
+            .expect("Alice failed to receive event")
+        else {
+            panic!("Alice received unexpected event")
+        };
+
+        let eve = participants
+            .iter()
+            .find(|p| p.id == eve.id)
+            .expect("Eve not found");
+
+        assert_eq!(eve.muted, true);
+        assert_eq!(eve.display, Some(new_display.clone()));
+
+        // Bob should receive the mute event of Eve
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::ParticipantsUpdated {
+            participants,
+            ..
+        }) = bob_events
+            .recv()
+            .await
+            .expect("Bob failed to receive event")
+        else {
+            panic!("Bob received unexpected event")
+        };
+
+        let eve = participants
+            .iter()
+            .find(|p| p.id == eve.id)
+            .expect("Eve not found");
+
+        assert_eq!(eve.muted, true);
+        assert_eq!(eve.display, Some(new_display.clone()));
+
+        // Eve should not receive muted event, instead it receives `"result": "ok"`
+        let PluginEvent::AudioBridgeEvent(AudioBridgeEvent::Other(_)) = eve_events
+            .recv()
+            .await
+            .expect("Eve failed to receive event")
+        else {
+            panic!("Eve received unexpected event")
+        };
     }
 
     'mute_room: {

--- a/jarust_interface/src/japrotocol.rs
+++ b/jarust_interface/src/japrotocol.rs
@@ -120,9 +120,9 @@ pub enum JsepType {
 pub struct Jsep {
     #[serde(rename = "type")]
     pub jsep_type: JsepType,
+    pub sdp: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trickle: Option<bool>,
-    pub sdp: String,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]

--- a/jarust_plugins/src/audio_bridge/handle.rs
+++ b/jarust_plugins/src/audio_bridge/handle.rs
@@ -231,17 +231,24 @@ impl AudioBridgeHandle {
     }
 
     /// Configure the media related settings of the participant
-    #[cfg(feature = "__experimental")]
     #[tracing::instrument(level = tracing::Level::DEBUG, skip_all)]
     pub async fn configure(
         &self,
         params: AudioBridgeConfigureParams,
+        jsep: Option<Jsep>,
         timeout: Duration,
     ) -> Result<(), jarust_interface::Error> {
         tracing::info!(plugin = "audiobridge", "Sending configure");
         let mut message: Value = params.try_into()?;
         message["request"] = "configure".into();
-        self.handle.send_waiton_ack(message, timeout).await?;
+        match jsep {
+            None => self.handle.send_waiton_ack(message, timeout).await?,
+            Some(jsep) => {
+                self.handle
+                    .send_waiton_ack_with_jsep(message, jsep, timeout)
+                    .await?
+            }
+        };
         Ok(())
     }
 

--- a/jarust_plugins/src/audio_bridge/params.rs
+++ b/jarust_plugins/src/audio_bridge/params.rs
@@ -266,7 +266,6 @@ pub enum AudioBridgeCodec {
     Pcmu,
 }
 
-#[cfg(feature = "__experimental")]
 make_dto!(
     AudioBridgeConfigureParams,
     optional {


### PR DESCRIPTION
- **fix: skip trickle field on serde if missing**
- **test: added configure request test case**
