### PR TITLE
fix: each handle level request waits on a different logic now

### DIFF
--- a/e2e/tests/core.rs
+++ b/e2e/tests/core.rs
@@ -63,7 +63,7 @@ async fn it_websocket_core_tests() {
         .await
         .unwrap();
 
-    handle.detach(Duration::from_secs(5)).await.unwrap();
+    handle.detach().await.unwrap();
     assert_eq!(
         event_recv.recv().await.unwrap().janus,
         ResponseType::Event(JaHandleEvent::GenericEvent(GenericEvent::Detached)),

--- a/jarust/tests/mocks/mock_interface.rs
+++ b/jarust/tests/mocks/mock_interface.rs
@@ -196,11 +196,15 @@ impl JanusInterface for MockInterface {
         todo!("Send message wait on ack with jsep is not implemented");
     }
 
-    async fn send_handle_request(
+    async fn send_handle_request(&self, _request: HandleMessage) -> Result<(), Error> {
+        todo!("Send handle request is not implemented");
+    }
+
+    async fn send_handle_request_waiton_ack(
         &self,
         _request: HandleMessage,
         _timeout: Duration,
-    ) -> Result<JaResponse, Error> {
-        todo!("Send handle request is not implemented");
+    ) -> Result<String, Error> {
+        todo!("Send handle request and waiting on ack is not implemented");
     }
 }

--- a/jarust_interface/src/janus_interface.rs
+++ b/jarust_interface/src/janus_interface.rs
@@ -102,12 +102,17 @@ pub trait JanusInterface: Debug + Send + Sync + 'static {
 
     /// Sends a top-level handle request.
     ///
-    /// This is used for requests like `hangup`, `detach`, `trickle`, etc.
-    async fn send_handle_request(
+    /// This is used for requests like `hangup`, `detach`, etc.
+    async fn send_handle_request(&self, request: HandleMessage) -> Result<(), Error>;
+
+    /// Sends a top-level handle request and wait on ack
+    ///
+    /// This is used for requests like 'trickle' so far.
+    async fn send_handle_request_waiton_ack(
         &self,
         request: HandleMessage,
         timeout: Duration,
-    ) -> Result<JaResponse, Error>;
+    ) -> Result<String, Error>;
 
     /// Returns the name of the interface (for the debug trait)
     fn name(&self) -> Box<str> {


### PR DESCRIPTION
Their are issues when calling trickle and hangup, because trickle isn't expecting any response (it returns an ack) and hungup doesn't return anything synchronously. Also it's an issue with destroy and detach